### PR TITLE
fix!: Decouple `Parser` from parser functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fn hex_primary(input: &str) -> IResult<&str, u8> {
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
   let (input, _) = tag("#").parse(input)?;
-  let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+  let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary)).parse(input)?;
 
   Ok((input, Color { red, green, blue }))
 }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fn hex_primary(input: &str) -> IResult<&str, u8> {
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
-  let (input, _) = tag("#")(input)?;
+  let (input, _) = tag("#").parse(input)?;
   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
 
   Ok((input, Color { red, green, blue }))

--- a/benchmarks/benches/json.rs
+++ b/benchmarks/benches/json.rs
@@ -30,7 +30,7 @@ pub enum JsonValue {
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
-  alt((value(false, tag("false")), value(true, tag("true"))))(input)
+  alt((value(false, tag("false")), value(true, tag("true")))).parse(input)
 }
 
 fn u16_hex(input: &str) -> IResult<&str, u16> {
@@ -78,7 +78,8 @@ fn character(input: &str) -> IResult<&str, char> {
         })
       }),
       preceded(char('u'), unicode_escape),
-    ))(input)
+    ))
+    .parse(input)
   } else {
     Ok((input, c))
   }
@@ -131,7 +132,8 @@ fn json_value(input: &str) -> IResult<&str, JsonValue> {
     map(double, Num),
     map(array, Array),
     map(object, Object),
-  ))(input)
+  ))
+  .parse(input)
 }
 
 fn json(input: &str) -> IResult<&str, JsonValue> {

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -11,7 +11,7 @@ fn main() {
   let mut data = "abcabcabcabc";
 
   fn parser(i: &str) -> IResult<&str, &str> {
-    tag("abc")(i)
+    tag("abc").parse(i)
   }
 
   // `from_fn` (available from Rust 1.34) can create an iterator

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -32,7 +32,7 @@ fn sp<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str, E> {
 
   // nom combinators like `take_while` return a function. That function is the
   // parser,to which we can pass the input
-  take_while(move |c| chars.contains(c))(i)
+  take_while(move |c| chars.contains(c)).parse(i)
 }
 
 /// A nom parser has the following signature:
@@ -51,7 +51,7 @@ fn sp<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str, E> {
 /// of the input data. and there is no allocation needed. This is the main idea
 /// behind nom's performance.
 fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str, E> {
-  escaped(alphanumeric, '\\', one_of("\"n\\"))(i)
+  escaped(alphanumeric, '\\', one_of("\"n\\")).parse(i)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -128,7 +128,8 @@ fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     preceded(sp, string),
     cut(preceded(sp, char(':'))),
     json_value,
-  )(i)
+  )
+  .parse(i)
 }
 
 fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -169,7 +170,8 @@ fn json_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
       map(boolean, JsonValue::Boolean),
       map(null, |_| JsonValue::Null),
     )),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// the root element of a JSON parser is either an object or an array
@@ -184,7 +186,8 @@ fn root<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
       map(null, |_| JsonValue::Null),
     )),
     opt(sp),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn main() {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -97,7 +97,8 @@ fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   context(
     "string",
     preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// some combinators, like `separated_list0` or `many0`, will call a parser repeatedly,
@@ -116,7 +117,8 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         preceded(sp, char(']')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -149,7 +151,8 @@ fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         preceded(sp, char('}')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// here, we apply the space parser before trying to parse a value

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -73,7 +73,7 @@ fn boolean<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, bool,
 
   // `alt` combines the two parsers. It returns the result of the first
   // successful parser, or an error
-  alt((parse_true, parse_false))(input)
+  alt((parse_true, parse_false)).parse(input)
 }
 
 fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -4,7 +4,7 @@ use nom::{
   branch::alt,
   bytes::complete::{escaped, tag, take_while},
   character::complete::{alphanumeric1 as alphanumeric, char, one_of},
-  combinator::{map, opt, cut},
+  combinator::{cut, map, opt},
   error::{context, ErrorKind, ParseError},
   error::{VerboseError, VerboseErrorKind},
   multi::separated_list,
@@ -14,8 +14,8 @@ use nom::{
 };
 use std::collections::HashMap;
 
-use std::str;
 use std::cell::Cell;
+use std::str;
 
 struct Cursor<'a> {
   inner: &'a str,
@@ -28,7 +28,7 @@ pub struct JsonValue<'a, 'b> {
   pub offset: &'b Cell<usize>,
 }
 
-impl<'a, 'b:'a> JsonValue<'a, 'b> {
+impl<'a, 'b: 'a> JsonValue<'a, 'b> {
   pub fn new(input: &'a str, offset: &'b Cell<usize>) -> JsonValue<'a, 'b> {
     JsonValue { input, offset }
   }
@@ -49,7 +49,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
         self.offset(i);
         println!("-> {}", s);
         Some(s)
-      },
+      }
       _ => None,
     }
   }
@@ -61,27 +61,27 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
         self.offset(i);
         println!("-> {}", o);
         Some(o)
-      },
+      }
       _ => None,
     }
   }
 
   pub fn number(&self) -> Option<f64> {
     println!("number()");
-    match double::<_,()>(self.data()) {
+    match double::<_, ()>(self.data()) {
       Ok((i, o)) => {
         self.offset(i);
         println!("-> {}", o);
         Some(o)
-      },
+      }
       _ => None,
     }
   }
 
-  pub fn array(&self) -> Option<impl Iterator<Item=JsonValue<'a, 'b>>> {
+  pub fn array(&self) -> Option<impl Iterator<Item = JsonValue<'a, 'b>>> {
     println!("array()");
 
-    match tag::<_,_,()>("[")(self.data()) {
+    match tag::<_, _, ()>("[")(self.data()) {
       Err(_) => None,
       Ok((i, _)) => {
         println!("[");
@@ -92,7 +92,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
 
         let v = self.clone();
 
-        Some(std::iter::from_fn(move|| {
+        Some(std::iter::from_fn(move || {
           if done {
             return None;
           }
@@ -103,30 +103,29 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             match value(v.data()) {
               Ok((i, _)) => {
                 v.offset(i);
-              },
-              Err(_) => {},
+              }
+              Err(_) => {}
             }
           }
 
-
-          match tag::<_,_,()>("]")(v.data()) {
+          match tag::<_, _, ()>("]")(v.data()) {
             Ok((i, _)) => {
               println!("]");
               v.offset(i);
               done = true;
               return None;
-            },
+            }
             Err(_) => {}
           };
 
           if first {
             first = false;
           } else {
-            match tag::<_,_,()>(",")(v.data()) {
+            match tag::<_, _, ()>(",")(v.data()) {
               Ok((i, _)) => {
-               println!(",");
+                println!(",");
                 v.offset(i);
-              },
+              }
               Err(_) => {
                 done = true;
                 return None;
@@ -137,15 +136,14 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
           println!("-> {}", v.data());
           previous = v.offset.get();
           Some(v.clone())
-
         }))
       }
     }
   }
 
-  pub fn object(&self) -> Option<impl Iterator<Item=(&'a str, JsonValue<'a, 'b>)>> {
+  pub fn object(&self) -> Option<impl Iterator<Item = (&'a str, JsonValue<'a, 'b>)>> {
     println!("object()");
-    match tag::<_,_,()>("{")(self.data()) {
+    match tag::<_, _, ()>("{")(self.data()) {
       Err(_) => None,
       Ok((i, _)) => {
         self.offset(i);
@@ -158,7 +156,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
 
         let v = self.clone();
 
-        Some(std::iter::from_fn(move|| {
+        Some(std::iter::from_fn(move || {
           if done {
             return None;
           }
@@ -169,29 +167,29 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             match value(v.data()) {
               Ok((i, _)) => {
                 v.offset(i);
-              },
-              Err(_) => {},
+              }
+              Err(_) => {}
             }
           }
 
-          match tag::<_,_,()>("}")(v.data()) {
+          match tag::<_, _, ()>("}")(v.data()) {
             Ok((i, _)) => {
               println!("}}");
               v.offset(i);
               done = true;
               return None;
-            },
+            }
             Err(_) => {}
           };
 
           if first {
             first = false;
           } else {
-            match tag::<_,_,()>(",")(v.data()) {
+            match tag::<_, _, ()>(",")(v.data()) {
               Ok((i, _)) => {
                 println!(",");
                 v.offset(i);
-              },
+              }
               Err(_) => {
                 done = true;
                 return None;
@@ -203,7 +201,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             Ok((i, key)) => {
               v.offset(i);
 
-              match tag::<_,_,()>(":")(v.data()) {
+              match tag::<_, _, ()>(":")(v.data()) {
                 Err(_) => None,
                 Ok((i, _)) => {
                   v.offset(i);
@@ -214,10 +212,9 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
                   Some((key, v.clone()))
                 }
               }
-            },
+            }
             _ => None,
           }
-
         }))
       }
     }
@@ -235,47 +232,44 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 }
 
 fn string<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
-  context("string",
-    preceded(
-      char('\"'),
-      cut(terminated(
-          parse_str,
-          char('\"')
-  ))))(i)
+  context(
+    "string",
+    preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
+  )(i)
 }
 
 fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
-  alt((
-      map(tag("false"), |_| false),
-      map(tag("true"), |_| true)
-  ))(input)
+  alt((map(tag("false"), |_| false), map(tag("true"), |_| true))).parse(input)
 }
 
 fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
   context(
     "array",
-    preceded(char('['),
-    cut(terminated(
-      map(separated_list(preceded(sp, char(',')), value), |_| ()),
-      preceded(sp, char(']'))))
-  ))(i)
+    preceded(
+      char('['),
+      cut(terminated(
+        map(separated_list(preceded(sp, char(',')), value), |_| ()),
+        preceded(sp, char(']')),
+      )),
+    ),
+  )(i)
 }
 
 fn key_value<'a>(i: &'a str) -> IResult<&'a str, (&'a str, ())> {
-separated_pair(preceded(sp, string), cut(preceded(sp, char(':'))), value)(i)
+  separated_pair(preceded(sp, string), cut(preceded(sp, char(':'))), value)(i)
 }
 
 fn hash<'a>(i: &'a str) -> IResult<&'a str, ()> {
   context(
     "map",
-    preceded(char('{'),
-    cut(terminated(
-      map(
-        separated_list(preceded(sp, char(',')), key_value),
-        |_| ()),
-      preceded(sp, char('}')),
-    ))
-  ))(i)
+    preceded(
+      char('{'),
+      cut(terminated(
+        map(separated_list(preceded(sp, char(',')), key_value), |_| ()),
+        preceded(sp, char('}')),
+      )),
+    ),
+  )(i)
 }
 
 fn value<'a>(i: &'a str) -> IResult<&'a str, ()> {
@@ -314,13 +308,17 @@ fn main() {
     let parser = JsonValue::new(data, &offset);
 
     if let Some(o) = parser.object() {
-      let s: HashMap<&str, &str> = o.filter(|(k,_)| *k == "users" )
-         .filter_map(|(_, v)| v.object()).flatten()
-         .filter_map(|(user, v)| v.object().map(|o| (user, o)))
-         .map(|(user, o)| {
-            o.filter(|(k,_)| *k == "city" )
-             .filter_map(move |(_, v)| v.string().map(|s| (user, s)))
-          }).flatten().collect();
+      let s: HashMap<&str, &str> = o
+        .filter(|(k, _)| *k == "users")
+        .filter_map(|(_, v)| v.object())
+        .flatten()
+        .filter_map(|(user, v)| v.object().map(|o| (user, o)))
+        .map(|(user, o)| {
+          o.filter(|(k, _)| *k == "city")
+            .filter_map(move |(_, v)| v.string().map(|s| (user, s)))
+        })
+        .flatten()
+        .collect();
 
       println!("res = {:?}", s);
     }

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -92,7 +92,8 @@ fn parse_builtin<'a>(i: &'a str) -> IResult<&'a str, BuiltIn, VerboseError<&'a s
     // map lets us process the parsed output, in this case we know what we parsed,
     // so we ignore the input and return the BuiltIn directly
     map(tag("not"), |_| BuiltIn::Not),
-  ))(i)
+  ))
+  .parse(i)
 }
 
 /// Our boolean values are also constant, so we can do it the same way
@@ -100,7 +101,8 @@ fn parse_bool<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
   alt((
     map(tag("#t"), |_| Atom::Boolean(true)),
     map(tag("#f"), |_| Atom::Boolean(false)),
-  ))(i)
+  ))
+  .parse(i)
 }
 
 /// The next easiest thing to parse are keywords.
@@ -126,7 +128,8 @@ fn parse_num<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
     map(preceded(tag("-"), digit1), |digit_str: &str| {
       Atom::Num(-1 * digit_str.parse::<i32>().unwrap())
     }),
-  ))(i)
+  ))
+  .parse(i)
 }
 
 /// Now we take all these simple parsers and connect them.
@@ -137,7 +140,8 @@ fn parse_atom<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
     parse_bool,
     map(parse_builtin, Atom::BuiltIn),
     parse_keyword,
-  ))(i)
+  ))
+  .parse(i)
 }
 
 /// We then add the Expr layer on top

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -115,7 +115,8 @@ fn parse_keyword<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>
   map(
     context("keyword", preceded(tag(":"), cut(alpha1))),
     |sym_str: &str| Atom::Keyword(sym_str.to_string()),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// Next up is number parsing. We're keeping it simple here by accepting any number (> 1)
@@ -146,7 +147,7 @@ fn parse_atom<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
 
 /// We then add the Expr layer on top
 fn parse_constant<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
-  map(parse_atom, |atom| Expr::Constant(atom))(i)
+  map(parse_atom, |atom| Expr::Constant(atom)).parse(i)
 }
 
 /// Before continuing, we need a helper function to parse lists.
@@ -235,7 +236,8 @@ fn parse_quote<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> 
   map(
     context("quote", preceded(tag("'"), cut(s_exp(many0(parse_expr))))),
     |exprs| Expr::Quote(exprs),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// We tie them all together again, making a top-level expression parser!

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -81,7 +81,8 @@ where
       value('/', char('/')),
       value('"', char('"')),
     )),
-  )(input)
+  )
+  .parse(input)
 }
 
 /// Parse a backslash, followed by any amount of whitespace. This is used later
@@ -89,7 +90,7 @@ where
 fn parse_escaped_whitespace<'a, E: ParseError<&'a str>>(
   input: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-  preceded(char('\\'), multispace1)(input)
+  preceded(char('\\'), multispace1).parse(input)
 }
 
 /// Parse a non-empty block of text that doesn't include \ or "
@@ -160,7 +161,7 @@ where
   // " character, the closing delimiter " would never match. When using
   // `delimited` with a looping parser (like fold_many0), be sure that the
   // loop won't accidentally match your closing delimiter!
-  delimited(char('"'), build_string, char('"'))(input)
+  delimited(char('"'), build_string, char('"')).parse(input)
 }
 
 fn main() {

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -127,7 +127,8 @@ where
     map(parse_literal, StringFragment::Literal),
     map(parse_escaped_char, StringFragment::EscapedChar),
     value(StringFragment::EscapedWS, parse_escaped_whitespace),
-  ))(input)
+  ))
+  .parse(input)
 }
 
 /// Parse a string. Use a loop of parse_fragment and push all of the fragments

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -15,63 +15,68 @@ use nom::{
   IResult,
 };
 
-use std::str::FromStr;
 use std::cell::RefCell;
+use std::str::FromStr;
 
 thread_local! {
     pub static LEVEL: RefCell<u32> = RefCell::new(0);
 }
 
 fn reset() {
-    LEVEL.with(|l| {
-        *l.borrow_mut() = 0;
-    });
+  LEVEL.with(|l| {
+    *l.borrow_mut() = 0;
+  });
 }
 
 fn incr(i: &str) -> IResult<&str, ()> {
-    LEVEL.with(|l| {
-        *l.borrow_mut() += 1;
+  LEVEL.with(|l| {
+    *l.borrow_mut() += 1;
 
-        // limit the number of recursions, the fuzzer keeps running into them
-        if *l.borrow() >= 8192 {
-            return Err(nom::Err::Failure(nom::error::Error::new(i, nom::error::ErrorKind::Count)));
-        } else {
-            Ok((i, ()))
-        }
-    })
+    // limit the number of recursions, the fuzzer keeps running into them
+    if *l.borrow() >= 8192 {
+      return Err(nom::Err::Failure(nom::error::Error::new(
+        i,
+        nom::error::ErrorKind::Count,
+      )));
+    } else {
+      Ok((i, ()))
+    }
+  })
 }
 
 fn decr() {
-    LEVEL.with(|l| {
-        *l.borrow_mut() -= 1;
-    });
+  LEVEL.with(|l| {
+    *l.borrow_mut() -= 1;
+  });
 }
 
 fn parens(i: &str) -> IResult<&str, i64> {
-      delimited(space, delimited(
-              terminated(tag("("), incr),
-              expr,
-              map(tag(")"),  |_| decr())
-      ), space)(i)
+  delimited(
+    space,
+    delimited(terminated(tag("("), incr), expr, map(tag(")"), |_| decr())),
+    space,
+  )(i)
 }
-
 
 fn factor(i: &str) -> IResult<&str, i64> {
   alt((
     map_res(delimited(space, digit, space), FromStr::from_str),
     parens,
-  ))(i)
+  ))
+  .parse(i)
 }
-
 
 fn term(i: &str) -> IResult<&str, i64> {
   incr(i)?;
-  let (i, init) = factor(i).map_err(|e| { decr(); e })?;
+  let (i, init) = factor(i).map_err(|e| {
+    decr();
+    e
+  })?;
 
   let res = fold_many0(
     alt((
-        pair(char('*'), factor),
-        pair(char('/'), verify(factor, |i| *i != 0)),
+      pair(char('*'), factor),
+      pair(char('/'), verify(factor, |i| *i != 0)),
     )),
     || init,
     |acc, (op, val): (char, i64)| {
@@ -79,14 +84,15 @@ fn term(i: &str) -> IResult<&str, i64> {
         acc.saturating_mul(val)
       } else {
         match acc.checked_div(val) {
-            Some(v) => v,
-            // we get a division with overflow because we can get acc = i64::MIN and val = -1
-            // the division by zero is already checked earlier by verify
-            None => i64::MAX,
+          Some(v) => v,
+          // we get a division with overflow because we can get acc = i64::MIN and val = -1
+          // the division by zero is already checked earlier by verify
+          None => i64::MAX,
         }
       }
     },
-  )(i);
+  )
+  .parse(i);
 
   decr();
   res
@@ -94,7 +100,10 @@ fn term(i: &str) -> IResult<&str, i64> {
 
 fn expr(i: &str) -> IResult<&str, i64> {
   incr(i)?;
-  let (i, init) = term(i).map_err(|e| { decr(); e })?;
+  let (i, init) = term(i).map_err(|e| {
+    decr();
+    e
+  })?;
 
   let res = fold_many0(
     pair(alt((char('+'), char('-'))), term),
@@ -113,13 +122,13 @@ fn expr(i: &str) -> IResult<&str, i64> {
 }
 
 fuzz_target!(|data: &[u8]| {
-    reset();
-    // fuzzed code goes here
-    let temp = match str::from_utf8(data) {
-        Ok(v) => {
-            //println!("v: {}", v);
-            factor(v)
-        },
-        Err(e) => factor("2"),
-    };
+  reset();
+  // fuzzed code goes here
+  let temp = match str::from_utf8(data) {
+    Ok(v) => {
+      //println!("v: {}", v);
+      factor(v)
+    }
+    Err(e) => factor("2"),
+  };
 });

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -5,6 +5,7 @@ use crate::error::{ErrorKind, ParseError};
 use crate::internal::{Err, IResult};
 use crate::lib::std::ops::{AddAssign, Div, RangeFrom, Shl, Shr};
 use crate::traits::{InputIter, InputLength, Slice, ToUsize};
+use crate::Parser;
 
 /// Generates a parser taking `count` bits
 ///
@@ -15,7 +16,7 @@ use crate::traits::{InputIter, InputLength, Slice, ToUsize};
 /// # use nom::error::{Error, ErrorKind};
 /// // Input is a tuple of (input: I, bit_offset: usize)
 /// fn parser(input: (&[u8], usize), count: usize)-> IResult<(&[u8], usize), u8> {
-///  take(count)(input)
+///  take(count).parse(input)
 /// }
 ///
 /// // Consumes 0 bits, returns 0
@@ -30,16 +31,33 @@ use crate::traits::{InputIter, InputLength, Slice, ToUsize};
 /// // Tries to consume 12 bits but only 8 are available
 /// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(nom::Err::Error(Error{input: ([0b00010010].as_ref(), 0), code: ErrorKind::Eof })));
 /// ```
-pub fn take<I, O, C, E: ParseError<(I, usize)>>(
+pub fn take<C, I, O, E>(count: C) -> Take<C, I, O, E> {
+  Take {
+    count,
+    i: Default::default(),
+    o: Default::default(),
+    e: Default::default(),
+  }
+}
+
+/// Implementation of [`take`]
+pub struct Take<C, I, O, E> {
   count: C,
-) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+  i: core::marker::PhantomData<I>,
+  o: core::marker::PhantomData<O>,
+  e: core::marker::PhantomData<E>,
+}
+
+impl<C, I, O, E> Take<C, I, O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
+  E: ParseError<(I, usize)>,
 {
-  let count = count.to_usize();
-  move |(input, bit_offset): (I, usize)| {
+  /// See [`Parser::parse`]
+  pub fn parse(&mut self, (input, bit_offset): (I, usize)) -> IResult<(I, usize), O, E> {
+    let count = self.count.to_usize();
     if count == 0 {
       Ok(((input, bit_offset), 0u8.into()))
     } else {
@@ -81,27 +99,67 @@ where
   }
 }
 
+impl<C, I, O, E> Parser<(I, usize), O, E> for Take<C, I, O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  C: ToUsize,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
+  E: ParseError<(I, usize)>,
+{
+  fn parse(&mut self, input: (I, usize)) -> IResult<(I, usize), O, E> {
+    self.parse(input)
+  }
+}
+
 /// Generates a parser taking `count` bits and comparing them to `pattern`
-pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
+pub fn tag<C, I, O, E>(pattern: O, count: C) -> Tag<C, I, O, E> {
+  Tag {
+    pattern,
+    count,
+    i: Default::default(),
+    e: Default::default(),
+  }
+}
+
+/// Implementation of [`tag`]
+pub struct Tag<C, I, O, E> {
   pattern: O,
   count: C,
-) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+  i: core::marker::PhantomData<I>,
+  e: core::marker::PhantomData<E>,
+}
+
+impl<C, I, O, E> Tag<C, I, O, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+  E: ParseError<(I, usize)>,
 {
-  let count = count.to_usize();
-  move |input: (I, usize)| {
+  /// See [`Parser::parse`]
+  pub fn parse(&mut self, input: (I, usize)) -> IResult<(I, usize), O, E> {
+    let count = self.count.to_usize();
     let inp = input.clone();
 
-    take(count)(input).and_then(|(i, o)| {
-      if pattern == o {
+    take(count).parse(input).and_then(|(i, o)| {
+      if self.pattern == o {
         Ok((i, o))
       } else {
         Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
       }
     })
+  }
+}
+
+impl<C, I, O, E> Parser<(I, usize), O, E> for Tag<C, I, O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  C: ToUsize,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+  E: ParseError<(I, usize)>,
+{
+  fn parse(&mut self, input: (I, usize)) -> IResult<(I, usize), O, E> {
+    self.parse(input)
   }
 }
 
@@ -116,7 +174,7 @@ mod test {
     assert_eq!(count, 0usize);
     let offset = 0usize;
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(count)((input, offset));
+    let result: crate::IResult<(&[u8], usize), usize> = take(count).parse((input, offset));
 
     assert_eq!(result, Ok(((input, offset), 0)));
   }
@@ -125,7 +183,7 @@ mod test {
   fn test_take_eof() {
     let input = [0b00010010].as_ref();
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(1usize)((input, 8));
+    let result: crate::IResult<(&[u8], usize), usize> = take(1usize).parse((input, 8));
 
     assert_eq!(
       result,
@@ -140,7 +198,7 @@ mod test {
   fn test_take_span_over_multiple_bytes() {
     let input = [0b00010010, 0b00110100, 0b11111111, 0b11111111].as_ref();
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(24usize)((input, 4));
+    let result: crate::IResult<(&[u8], usize), usize> = take(24usize).parse((input, 4));
 
     assert_eq!(
       result,

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -110,7 +110,7 @@ where
 ///   bits::<_, Error<(&[u8], usize)>, _, _, _>(tuple((
 ///     take(4usize),
 ///     take(8usize),
-///     bytes::<_, Error<&[u8]>, _, _, _>(rest)
+///     bytes::<_, Error<&[u8]>, _, _, _>(rest())
 ///   ))).parse(input)
 /// }
 ///

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -169,37 +169,37 @@ impl<Input, Output, Error: ParseError<Input>, A: Parser<Input, Output, Error>>
 
 macro_rules! permutation_trait(
   (
-    $name1:ident $ty1:ident $item1:ident
-    $name2:ident $ty2:ident $item2:ident
-    $($name3:ident $ty3:ident $item3:ident)*
+    $parser1:ident $output1:ident $item1:ident
+    $parser2:ident $output2:ident $item2:ident
+    $($parser3:ident $output3:ident $item3:ident)*
   ) => (
-    permutation_trait!(__impl $name1 $ty1 $item1, $name2 $ty2 $item2; $($name3 $ty3 $item3)*);
+    permutation_trait!(__impl $parser1 $output1 $item1, $parser2 $output2 $item2; $($parser3 $output3 $item3)*);
   );
   (
-    __impl $($name:ident $ty:ident $item:ident),+;
-    $name1:ident $ty1:ident $item1:ident $($name2:ident $ty2:ident $item2:ident)*
+    __impl $($parser:ident $output:ident $item:ident),+;
+    $parser1:ident $output1:ident $item1:ident $($parser2:ident $output2:ident $item2:ident)*
   ) => (
-    permutation_trait_impl!($($name $ty $item),+);
-    permutation_trait!(__impl $($name $ty $item),+ , $name1 $ty1 $item1; $($name2 $ty2 $item2)*);
+    permutation_trait_impl!($($parser $output $item),+);
+    permutation_trait!(__impl $($parser $output $item),+ , $parser1 $output1 $item1; $($parser2 $output2 $item2)*);
   );
-  (__impl $($name:ident $ty:ident $item:ident),+;) => (
-    permutation_trait_impl!($($name $ty $item),+);
+  (__impl $($parser:ident $output:ident $item:ident),+;) => (
+    permutation_trait_impl!($($parser $output $item),+);
   );
 );
 
 macro_rules! permutation_trait_impl(
-  ($($name:ident $ty:ident $item:ident),+) => (
+  ($($parser:ident $output:ident $item:ident),+) => (
     impl<
-      Input: Clone, $($ty),+ , Error: ParseError<Input>,
-      $($name: Parser<Input, $ty, Error>),+
-    > Permutation<Input, ( $($ty),+ ), Error> for ( $($name),+ ) {
+      Input: Clone, $($output),+ , Error: ParseError<Input>,
+      $($parser: Parser<Input, $output, Error>),+
+    > Permutation<Input, ( $($output),+ ), Error> for ( $($parser),+ ) {
 
-      fn permutation(&mut self, mut input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
-        let mut res = ($(Option::<$ty>::None),+);
+      fn permutation(&mut self, mut input: Input) -> IResult<Input, ( $($output),+ ), Error> {
+        let mut res = ($(Option::<$output>::None),+);
 
         loop {
           let mut err: Option<Error> = None;
-          permutation_trait_inner!(0, self, input, res, err, $($name)+);
+          permutation_trait_inner!(0, self, input, res, err, $($parser)+);
 
           // If we reach here, every iterator has either been applied before,
           // or errored on the remaining input
@@ -243,25 +243,25 @@ macro_rules! permutation_trait_inner(
 );
 
 permutation_trait!(
-  FnA A a
-  FnB B b
-  FnC C c
-  FnD D d
-  FnE E e
-  FnF F f
-  FnG G g
-  FnH H h
-  FnI I i
-  FnJ J j
-  FnK K k
-  FnL L l
-  FnM M m
-  FnN N n
-  FnO O o
-  FnP P p
-  FnQ Q q
-  FnR R r
-  FnS S s
-  FnT T t
-  FnU U u
+  AParser AParserOutput a_value
+  BParser BParserOutput b_value
+  CParser CParserOutput c_value
+  DParser DParserOutput d_value
+  EParser EParserOutput e_value
+  FParser FParserOutput f_value
+  GParser GParserOutput g_value
+  HParser HParserOutput h_value
+  IParser IParserOutput i_value
+  JParser JParserOutput j_value
+  KParser KParserOutput k_value
+  LParser LParserOutput l_value
+  MParser MParserOutput m_value
+  NParser NParserOutput n_value
+  OParser OParserOutput o_value
+  PParser PParserOutput p_value
+  QParser QParserOutput q_value
+  RParser RParserOutput r_value
+  SParser SParserOutput s_value
+  TParser TParserOutput t_value
+  UParser UParserOutput u_value
 );

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -1,7 +1,8 @@
 use crate::branch::{alt, permutation};
 use crate::bytes::streaming::tag;
 use crate::error::ErrorKind;
-use crate::internal::{Err, IResult, Needed};
+use crate::internal::{Err, IResult, Needed, Parser};
+
 #[cfg(feature = "alloc")]
 use crate::{
   error::ParseError,
@@ -60,13 +61,13 @@ fn alt_test() {
   }
 
   fn alt1(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    alt((dont_work, dont_work))(i)
+    alt((dont_work, dont_work)).parse(i)
   }
   fn alt2(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    alt((dont_work, work))(i)
+    alt((dont_work, work)).parse(i)
   }
   fn alt3(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    alt((dont_work, dont_work, work2, dont_work))(i)
+    alt((dont_work, dont_work, work2, dont_work)).parse(i)
   }
   //named!(alt1, alt!(dont_work | dont_work));
   //named!(alt2, alt!(dont_work | work));
@@ -85,7 +86,7 @@ fn alt_test() {
   assert_eq!(alt3(a), Ok((a, &b""[..])));
 
   fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    alt((tag("abcd"), tag("efgh")))(i)
+    alt((tag("abcd"), tag("efgh"))).parse(i)
   }
   let b = &b"efgh"[..];
   assert_eq!(alt4(a), Ok((&b""[..], a)));
@@ -95,7 +96,7 @@ fn alt_test() {
 #[test]
 fn alt_incomplete() {
   fn alt1(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    alt((tag("a"), tag("bc"), tag("def")))(i)
+    alt((tag("a"), tag("bc"), tag("def"))).parse(i)
   }
 
   let a = &b""[..];
@@ -115,7 +116,7 @@ fn alt_incomplete() {
 #[test]
 fn permutation_test() {
   fn perm(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8], &[u8])> {
-    permutation((tag("abcd"), tag("efg"), tag("hi")))(i)
+    permutation((tag("abcd"), tag("efg"), tag("hi"))).parse(i)
   }
 
   let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -1153,7 +1153,8 @@ mod tests {
       char('"'),
       escaped(opt(none_of(r#"\""#)), '\\', one_of(r#"\"rnt"#)),
       char('"'),
-    )(input)
+    )
+    .parse(input)
   }
 
   #[test]

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -72,7 +72,7 @@ fn escaping() {
   use crate::character::streaming::one_of;
 
   fn esc(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    escaped(alpha, '\\', one_of("\"n\\"))(i)
+    escaped(alpha, '\\', one_of("\"n\\")).parse(i)
   }
   assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], &b"abcd"[..])));
   assert_eq!(esc(&b"ab\\\"cd;"[..]), Ok((&b";"[..], &b"ab\\\"cd"[..])));
@@ -96,7 +96,7 @@ fn escaping() {
   );
 
   fn esc2(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    escaped(digit, '\\', one_of("\"n\\"))(i)
+    escaped(digit, '\\', one_of("\"n\\")).parse(i)
   }
   assert_eq!(esc2(&b"12\\nnn34"[..]), Ok((&b"nn34"[..], &b"12\\n"[..])));
 }
@@ -107,7 +107,7 @@ fn escaping_str() {
   use crate::character::streaming::one_of;
 
   fn esc(i: &str) -> IResult<&str, &str> {
-    escaped(alpha, '\\', one_of("\"n\\"))(i)
+    escaped(alpha, '\\', one_of("\"n\\")).parse(i)
   }
   assert_eq!(esc("abcd;"), Ok((";", "abcd")));
   assert_eq!(esc("ab\\\"cd;"), Ok((";", "ab\\\"cd")));
@@ -128,12 +128,12 @@ fn escaping_str() {
   );
 
   fn esc2(i: &str) -> IResult<&str, &str> {
-    escaped(digit, '\\', one_of("\"n\\"))(i)
+    escaped(digit, '\\', one_of("\"n\\")).parse(i)
   }
   assert_eq!(esc2("12\\nnn34"), Ok(("nn34", "12\\n")));
 
   fn esc3(i: &str) -> IResult<&str, &str> {
-    escaped(alpha, '\u{241b}', one_of("\"n"))(i)
+    escaped(alpha, '\u{241b}', one_of("\"n")).parse(i)
   }
   assert_eq!(esc3("ab␛ncd;"), Ok((";", "ab␛ncd")));
 }
@@ -226,7 +226,8 @@ fn escape_transform_str() {
         value("\"", tag("\"")),
         value("\n", tag("n")),
       )),
-    )(i)
+    )
+    .parse(i)
   }
 
   assert_eq!(esc("abcd;"), Ok((";", String::from("abcd"))));
@@ -255,7 +256,8 @@ fn escape_transform_str() {
       alpha,
       '&',
       alt((value("è", tag("egrave;")), value("à", tag("agrave;")))),
-    )(i)
+    )
+    .parse(i)
   }
   assert_eq!(esc2("ab&egrave;DEF;"), Ok((";", String::from("abèDEF"))));
   assert_eq!(
@@ -268,7 +270,8 @@ fn escape_transform_str() {
       alpha,
       '␛',
       alt((value("\0", tag("0")), value("\n", tag("n")))),
-    )(i)
+    )
+    .parse(i)
   }
   assert_eq!(esc3("a␛0bc␛n"), Ok(("", String::from("a\0bc\n"))));
 }

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -158,7 +158,8 @@ fn escape_transform() {
         )),
       ),
       to_s,
-    )(i)
+    )
+    .parse(i)
   }
 
   assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], String::from("abcd"))));
@@ -202,7 +203,8 @@ fn escape_transform() {
         )),
       ),
       to_s,
-    )(i)
+    )
+    .parse(i)
   }
   assert_eq!(
     esc2(&b"ab&egrave;DEF;"[..]),

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -19,7 +19,7 @@ fn is_a() {
   use crate::bytes::streaming::is_a;
 
   fn a_or_b(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    is_a("ab")(i)
+    is_a("ab").parse(i)
   }
 
   let a = &b"abcd"[..];
@@ -43,7 +43,7 @@ fn is_not() {
   use crate::bytes::streaming::is_not;
 
   fn a_or_b(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    is_not("ab")(i)
+    is_not("ab").parse(i)
   }
 
   let a = &b"cdab"[..];
@@ -280,7 +280,7 @@ fn escape_transform_str() {
 fn take_until_incomplete() {
   use crate::bytes::streaming::take_until;
   fn y(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_until("end")(i)
+    take_until("end").parse(i)
   }
   assert_eq!(y(&b"nd"[..]), Err(Err::Incomplete(Needed::Unknown)));
   assert_eq!(y(&b"123"[..]), Err(Err::Incomplete(Needed::Unknown)));
@@ -291,7 +291,7 @@ fn take_until_incomplete() {
 fn take_until_incomplete_s() {
   use crate::bytes::streaming::take_until;
   fn ys(i: &str) -> IResult<&str, &str> {
-    take_until("end")(i)
+    take_until("end").parse(i)
   }
   assert_eq!(ys("123en"), Err(Err::Incomplete(Needed::Unknown)));
 }
@@ -358,7 +358,7 @@ fn take_while() {
   use crate::bytes::streaming::take_while;
 
   fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_while(AsChar::is_alpha)(i)
+    take_while(AsChar::is_alpha).parse(i)
   }
   let a = b"";
   let b = b"abcd";
@@ -376,7 +376,7 @@ fn take_while1() {
   use crate::bytes::streaming::take_while1;
 
   fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_while1(AsChar::is_alpha)(i)
+    take_while1(AsChar::is_alpha).parse(i)
   }
   let a = b"";
   let b = b"abcd";
@@ -397,7 +397,7 @@ fn take_while_m_n() {
   use crate::bytes::streaming::take_while_m_n;
 
   fn x(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_while_m_n(2, 4, AsChar::is_alpha)(i)
+    take_while_m_n(2, 4, AsChar::is_alpha).parse(i)
   }
   let a = b"";
   let b = b"a";
@@ -422,7 +422,7 @@ fn take_till() {
   use crate::bytes::streaming::take_till;
 
   fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_till(AsChar::is_alpha)(i)
+    take_till(AsChar::is_alpha).parse(i)
   }
   let a = b"";
   let b = b"abcd";
@@ -440,7 +440,7 @@ fn take_till1() {
   use crate::bytes::streaming::take_till1;
 
   fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_till1(AsChar::is_alpha)(i)
+    take_till1(AsChar::is_alpha).parse(i)
   }
   let a = b"";
   let b = b"abcd";
@@ -461,7 +461,7 @@ fn take_while_utf8() {
   use crate::bytes::streaming::take_while;
 
   fn f(i: &str) -> IResult<&str, &str> {
-    take_while(|c| c != '點')(i)
+    take_while(|c| c != '點').parse(i)
   }
 
   assert_eq!(f(""), Err(Err::Incomplete(Needed::new(1))));
@@ -470,7 +470,7 @@ fn take_while_utf8() {
   assert_eq!(f("abcd點a"), Ok(("點a", "abcd")));
 
   fn g(i: &str) -> IResult<&str, &str> {
-    take_while(|c| c == '點')(i)
+    take_while(|c| c == '點').parse(i)
   }
 
   assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
@@ -483,7 +483,7 @@ fn take_till_utf8() {
   use crate::bytes::streaming::take_till;
 
   fn f(i: &str) -> IResult<&str, &str> {
-    take_till(|c| c == '點')(i)
+    take_till(|c| c == '點').parse(i)
   }
 
   assert_eq!(f(""), Err(Err::Incomplete(Needed::new(1))));
@@ -492,7 +492,7 @@ fn take_till_utf8() {
   assert_eq!(f("abcd點a"), Ok(("點a", "abcd")));
 
   fn g(i: &str) -> IResult<&str, &str> {
-    take_till(|c| c != '點')(i)
+    take_till(|c| c != '點').parse(i)
   }
 
   assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
@@ -505,7 +505,7 @@ fn take_utf8() {
   use crate::bytes::streaming::{take, take_while};
 
   fn f(i: &str) -> IResult<&str, &str> {
-    take(3_usize)(i)
+    take(3_usize).parse(i)
   }
 
   assert_eq!(f(""), Err(Err::Incomplete(Needed::Unknown)));
@@ -516,7 +516,7 @@ fn take_utf8() {
   assert_eq!(f("a點b"), Ok(("", "a點b")));
 
   fn g(i: &str) -> IResult<&str, &str> {
-    take_while(|c| c == '點')(i)
+    take_while(|c| c == '點').parse(i)
   }
 
   assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
@@ -529,7 +529,7 @@ fn take_while_m_n_utf8() {
   use crate::bytes::streaming::take_while_m_n;
 
   fn parser(i: &str) -> IResult<&str, &str> {
-    take_while_m_n(1, 1, |c| c == 'A' || c == '😃')(i)
+    take_while_m_n(1, 1, |c| c == 'A' || c == '😃').parse(i)
   }
   assert_eq!(parser("A!"), Ok(("!", "A")));
   assert_eq!(parser("😃!"), Ok(("!", "😃")));
@@ -540,7 +540,7 @@ fn take_while_m_n_utf8_full_match() {
   use crate::bytes::streaming::take_while_m_n;
 
   fn parser(i: &str) -> IResult<&str, &str> {
-    take_while_m_n(1, 1, |c: char| c.is_alphabetic())(i)
+    take_while_m_n(1, 1, |c: char| c.is_alphabetic()).parse(i)
   }
   assert_eq!(parser("øn"), Ok(("n", "ø")));
 }
@@ -552,7 +552,7 @@ fn recognize_take_while() {
   use crate::combinator::recognize;
 
   fn x(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_while(AsChar::is_alphanum)(i)
+    take_while(AsChar::is_alphanum).parse(i)
   }
   fn y(i: &[u8]) -> IResult<&[u8], &[u8]> {
     recognize(x)(i)
@@ -575,7 +575,7 @@ fn length_bytes() {
   assert_eq!(x(b"\x02"), Err(Err::Incomplete(Needed::new(2))));
 
   fn y(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    let (i, _) = tag("magic")(i)?;
+    let (i, _) = tag("magic").parse(i)?;
     length_data(le_u8)(i)
   }
   assert_eq!(y(b"magic\x02..>>"), Ok((&b">>"[..], &b".."[..])));
@@ -590,7 +590,7 @@ fn case_insensitive() {
   use crate::bytes::streaming::tag_no_case;
 
   fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag_no_case("ABcd")(i)
+    tag_no_case("ABcd").parse(i)
   }
   assert_eq!(test(&b"aBCdefgh"[..]), Ok((&b"efgh"[..], &b"aBCd"[..])));
   assert_eq!(test(&b"abcdefgh"[..]), Ok((&b"efgh"[..], &b"abcd"[..])));
@@ -606,7 +606,7 @@ fn case_insensitive() {
   );
 
   fn test2(i: &str) -> IResult<&str, &str> {
-    tag_no_case("ABcd")(i)
+    tag_no_case("ABcd").parse(i)
   }
   assert_eq!(test2("aBCdefgh"), Ok(("efgh", "aBCd")));
   assert_eq!(test2("abcdefgh"), Ok(("efgh", "abcd")));
@@ -627,10 +627,10 @@ fn tag_fixed_size_array() {
   use crate::bytes::streaming::tag;
 
   fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag([0x42])(i)
+    tag([0x42]).parse(i)
   }
   fn test2(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag(&[0x42])(i)
+    tag(&[0x42]).parse(i)
   }
   let input = [0x42, 0x00];
   assert_eq!(test(&input), Ok((&b"\x00"[..], &b"\x42"[..])));

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -1084,7 +1084,7 @@ mod tests {
   fn full_line_windows() {
     use crate::sequence::pair;
     fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-      pair(not_line_ending, line_ending)(i)
+      pair(not_line_ending, line_ending).parse(i)
     }
     let input = b"abc\r\n";
     let output = take_full_line(input);
@@ -1095,7 +1095,7 @@ mod tests {
   fn full_line_unix() {
     use crate::sequence::pair;
     fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-      pair(not_line_ending, line_ending)(i)
+      pair(not_line_ending, line_ending).parse(i)
     }
     let input = b"abc\n";
     let output = take_full_line(input);

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -1049,7 +1049,7 @@ mod tests {
   #[test]
   fn full_line_windows() {
     fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-      pair(not_line_ending, line_ending)(i)
+      pair(not_line_ending, line_ending).parse(i)
     }
     let input = b"abc\r\n";
     let output = take_full_line(input);
@@ -1059,7 +1059,7 @@ mod tests {
   #[test]
   fn full_line_unix() {
     fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-      pair(not_line_ending, line_ending)(i)
+      pair(not_line_ending, line_ending).parse(i)
     }
     let input = b"abc\n";
     let output = take_full_line(input);

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1059,7 +1059,7 @@ enum State<E> {
 /// specify the default case.
 ///
 /// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult};
+/// # use nom::{Err,error::ErrorKind, IResult, Parser};
 /// use nom::branch::alt;
 /// use nom::combinator::{success, value};
 /// use nom::character::complete::char;
@@ -1069,9 +1069,9 @@ enum State<E> {
 /// assert_eq!(parser("xyz"), Ok(("xyz", 10)));
 ///
 /// let mut sign = alt((value(-1, char('-')), value(1, char('+')), success::<_,_,(_,ErrorKind)>(1)));
-/// assert_eq!(sign("+10"), Ok(("10", 1)));
-/// assert_eq!(sign("-10"), Ok(("10", -1)));
-/// assert_eq!(sign("10"), Ok(("10", 1)));
+/// assert_eq!(sign.parse("+10"), Ok(("10", 1)));
+/// assert_eq!(sign.parse("-10"), Ok(("10", -1)));
+/// assert_eq!(sign.parse("10"), Ok(("10", 1)));
 /// # }
 /// ```
 pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I, O, E> {

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -73,20 +73,29 @@ fn end_of_input() {
 fn rest_on_slices() {
   let input: &[u8] = &b"Hello, world!"[..];
   let empty: &[u8] = &b""[..];
-  assert_parse!(rest(input), Ok((empty, input)));
+  assert_parse!(
+    rest::<_, (&[u8], ErrorKind)>().parse(input),
+    Ok((empty, input))
+  );
 }
 
 #[test]
 fn rest_on_strs() {
   let input: &str = "Hello, world!";
   let empty: &str = "";
-  assert_parse!(rest(input), Ok((empty, input)));
+  assert_parse!(
+    rest::<_, (&str, ErrorKind)>().parse(input),
+    Ok((empty, input))
+  );
 }
 
 #[test]
 fn rest_len_on_slices() {
   let input: &[u8] = &b"Hello, world!"[..];
-  assert_parse!(rest_len(input), Ok((input, input.len())));
+  assert_parse!(
+    rest_len::<_, (&str, ErrorKind)>().parse(input),
+    Ok((input, input.len()))
+  );
 }
 
 use crate::lib::std::convert::From;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -241,12 +241,12 @@ pub trait Parser<I, O, E> {
   fn parse(&mut self, input: I) -> IResult<I, O, E>;
 
   /// Maps a function over the result of a parser
-  fn map<G, O2>(self, g: G) -> Map<Self, G, O>
+  fn map<F, FO>(self, transform: F) -> Map<Self, O, F, I, FO, E>
   where
-    G: Fn(O) -> O2,
+    F: Fn(O) -> FO,
     Self: core::marker::Sized,
   {
-    Map::new(self, g)
+    map(self, transform)
   }
 
   /// Creates a second parser from the output of the first one, then apply over the rest of the input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! }
 //!
 //! fn hex_color(input: &str) -> IResult<&str, Color> {
-//!   let (input, _) = tag("#")(input)?;
+//!   let (input, _) = tag("#").parse(input)?;
 //!   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
 //!
 //!   Ok((input, Color { red, green, blue }))
@@ -185,11 +185,11 @@
 //! use nom::IResult;
 //! use nom::bytes::complete::{tag, take};
 //! fn abcd_parser(i: &str) -> IResult<&str, &str> {
-//!   tag("abcd")(i) // will consume bytes if the input begins with "abcd"
+//!   tag("abcd").parse(i) // will consume bytes if the input begins with "abcd"
 //! }
 //!
 //! fn take_10(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   take(10u8)(i) // will consume and return 10 bytes of input
+//!   take(10u8).parse(i) // will consume and return 10 bytes of input
 //! }
 //! ```
 //!
@@ -299,9 +299,9 @@
 //!
 //! fn f(i: &[u8]) -> IResult<&[u8], A> {
 //!   // if successful, the parser returns `Ok((remaining_input, output_value))` that we can destructure
-//!   let (i, _) = tag("abcd")(i)?;
+//!   let (i, _) = tag("abcd").parse(i)?;
 //!   let (i, a) = ret_int1(i)?;
-//!   let (i, _) = tag("efgh")(i)?;
+//!   let (i, _) = tag("efgh").parse(i)?;
 //!   let (i, b) = ret_int2(i)?;
 //!
 //!   Ok((i, A { a, b }))
@@ -335,7 +335,7 @@
 //! }
 //!
 //! fn take_complete(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   bytes::complete::take(4u8)(i)
+//!   bytes::complete::take(4u8).parse(i)
 //! }
 //!
 //! // both parsers will take 4 bytes as expected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@
 //! ```rust
 //! use nom::{IResult, bytes::streaming::take};
 //! fn take4(input: &str) -> IResult<&str, &str> {
-//!   take(4u8)(input)
+//!   take(4u8).parse(input)
 //! }
 //! ```
 //!
@@ -331,7 +331,7 @@
 //! use nom::{IResult, Err, Needed, error::{Error, ErrorKind}, bytes, character};
 //!
 //! fn take_streaming(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   bytes::streaming::take(4u8)(i)
+//!   bytes::streaming::take(4u8).parse(i)
 //! }
 //!
 //! fn take_complete(i: &[u8]) -> IResult<&[u8], &[u8]> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! fn hex_color(input: &str) -> IResult<&str, Color> {
 //!   let (input, _) = tag("#").parse(input)?;
-//!   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+//!   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary)).parse(input)?;
 //!
 //!   Ok((input, Color { red, green, blue }))
 //! }
@@ -269,15 +269,15 @@
 //! let mut tpl = tuple((be_u16, take(3u8), tag("fg")));
 //!
 //! assert_eq!(
-//!   tpl(&b"abcdefgh"[..]),
+//!   tpl.parse(&b"abcdefgh"[..]),
 //!   Ok((
 //!     &b"h"[..],
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl(&b"abcde"[..]), Err(nom::Err::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse(&b"abcde"[..]), Err(nom::Err::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl(input), Err(nom::Err::Error((&input[5..], ErrorKind::Tag))));
+//! assert_eq!(tpl.parse(input), Err(nom::Err::Error((&input[5..], ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //! };
 //!
 //! fn parens(input: &str) -> IResult<&str, &str> {
-//!   delimited(char('('), is_not(")"), char(')'))(input)
+//!   delimited(char('('), is_not(")"), char(')')).parse(input)
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,14 +201,15 @@
 //!
 //! ```rust
 //! use nom::IResult;
+//! use nom::Parser;
 //! use nom::branch::alt;
 //! use nom::bytes::complete::tag;
 //!
 //! let mut alt_tags = alt((tag("abcd"), tag("efgh")));
 //!
-//! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
-//! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
-//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(nom::Err::Error((&b"ijklxxx"[..], nom::error::ErrorKind::Tag))));
+//! assert_eq!(alt_tags.parse(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
+//! assert_eq!(alt_tags.parse(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
+//! assert_eq!(alt_tags.parse(&b"ijklxxx"[..]), Err(nom::Err::Error((&b"ijklxxx"[..], nom::error::ErrorKind::Tag))));
 //! ```
 //!
 //! The **`opt`** combinator makes a parser optional. If the child parser returns

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1355,7 +1355,7 @@ where
 /// ```
 #[inline]
 pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u32, E> {
-  let (i, o) = crate::bytes::complete::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
+  let (i, o) = crate::bytes::complete::is_a(&b"0123456789abcdefABCDEF"[..]).parse(input)?;
   // Do not parse more than 8 characters for a u32
   let (parsed, remaining) = if o.len() <= 8 {
     (o, i)
@@ -1440,15 +1440,18 @@ where
       })
     },
     |i: T| {
-      crate::bytes::complete::tag_no_case::<_, _, E>("nan")(i.clone())
+      crate::bytes::complete::tag_no_case::<_, _, E>("nan")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
+      crate::bytes::complete::tag_no_case::<_, _, E>("inf")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
+      crate::bytes::complete::tag_no_case::<_, _, E>("infinity")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1451,7 +1451,8 @@ where
       crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
-  ))(input)
+  ))
+  .parse(input)
 }
 
 /// Recognizes a floating point number in text format

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1325,7 +1325,7 @@ where
 /// ```
 #[inline]
 pub fn hex_u32<'a, E: ParseError<&'a [u8]>>(input: &'a [u8]) -> IResult<&'a [u8], u32, E> {
-  let (i, o) = crate::bytes::streaming::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
+  let (i, o) = crate::bytes::streaming::is_a(&b"0123456789abcdefABCDEF"[..]).parse(input)?;
 
   // Do not parse more than 8 characters for a u32
   let (parsed, remaining) = if o.len() <= 8 {
@@ -1410,15 +1410,18 @@ where
       })
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("nan")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("nan")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")
+        .parse(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1421,7 +1421,8 @@ where
       crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
-  ))(input)
+  ))
+  .parse(input)
 }
 
 /// Recognizes a floating point number in text format

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -186,12 +186,38 @@ where
   }
 }
 
+///Applies a tuple of parsers one by one and returns their results as a tuple.
+///There is a maximum of 21 parsers
+/// ```rust
+/// # use nom::{Err, error::ErrorKind};
+/// use nom::sequence::tuple;
+/// use nom::character::complete::{alpha1, digit1};
+/// let mut parser = tuple((alpha1, digit1, alpha1));
+///
+/// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
+/// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
+/// ```
+pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
+  mut l: List,
+) -> impl FnMut(I) -> IResult<I, O, E> {
+  move |i: I| l.parse(i)
+}
+
 /// Helper trait for the tuple combinator.
 ///
 /// This trait is implemented for tuples of parsers of up to 21 elements.
 pub trait Tuple<I, O, E> {
   /// Parses the input and returns a tuple of results of each parser.
   fn parse(&mut self, input: I) -> IResult<I, O, E>;
+}
+
+// Special case: implement `Tuple` for `()`, the unit type.
+// This can come up in macros which accept a variable number of arguments.
+// Literally, `()` is an empty tuple, so it should simply parse nothing.
+impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
+  fn parse(&mut self, input: I) -> IResult<I, (), E> {
+    Ok((input, ()))
+  }
 }
 
 impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
@@ -201,20 +227,6 @@ impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
     self.0.parse(input).map(|(i, o)| (i, (o,)))
   }
 }
-
-macro_rules! tuple_trait(
-  ($name1:ident $ty1:ident, $name2: ident $ty2:ident, $($name:ident $ty:ident),*) => (
-    tuple_trait!(__impl $name1 $ty1, $name2 $ty2; $($name $ty),*);
-  );
-  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident, $($name2:ident $ty2:ident),*) => (
-    tuple_trait_impl!($($name $ty),+);
-    tuple_trait!(__impl $($name $ty),+ , $name1 $ty1; $($name2 $ty2),*);
-  );
-  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident) => (
-    tuple_trait_impl!($($name $ty),+);
-    tuple_trait_impl!($($name $ty),+, $name1 $ty1);
-  );
-);
 
 macro_rules! tuple_trait_impl(
   ($($name:ident $ty: ident),+) => (
@@ -249,31 +261,19 @@ macro_rules! tuple_trait_inner(
   });
 );
 
+macro_rules! tuple_trait(
+  ($name1:ident $ty1:ident, $name2: ident $ty2:ident, $($name:ident $ty:ident),*) => (
+    tuple_trait!(__impl $name1 $ty1, $name2 $ty2; $($name $ty),*);
+  );
+  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident, $($name2:ident $ty2:ident),*) => (
+    tuple_trait_impl!($($name $ty),+);
+    tuple_trait!(__impl $($name $ty),+ , $name1 $ty1; $($name2 $ty2),*);
+  );
+  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident) => (
+    tuple_trait_impl!($($name $ty),+);
+    tuple_trait_impl!($($name $ty),+, $name1 $ty1);
+  );
+);
+
 tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L,
   FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU U);
-
-// Special case: implement `Tuple` for `()`, the unit type.
-// This can come up in macros which accept a variable number of arguments.
-// Literally, `()` is an empty tuple, so it should simply parse nothing.
-impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
-  fn parse(&mut self, input: I) -> IResult<I, (), E> {
-    Ok((input, ()))
-  }
-}
-
-///Applies a tuple of parsers one by one and returns their results as a tuple.
-///There is a maximum of 21 parsers
-/// ```rust
-/// # use nom::{Err, error::ErrorKind};
-/// use nom::sequence::tuple;
-/// use nom::character::complete::{alpha1, digit1};
-/// let mut parser = tuple((alpha1, digit1, alpha1));
-///
-/// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
-/// ```
-pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
-  mut l: List,
-) -> impl FnMut(I) -> IResult<I, O, E> {
-  move |i: I| l.parse(i)
-}

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -228,7 +228,7 @@ impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
   }
 }
 
-macro_rules! tuple_trait_impl(
+macro_rules! impl_tuple(
   ($($name:ident $ty: ident),+) => (
     impl<
       Input: Clone, $($ty),+ , Error: ParseError<Input>,
@@ -236,23 +236,22 @@ macro_rules! tuple_trait_impl(
     > Tuple<Input, ( $($ty),+ ), Error> for ( $($name),+ ) {
 
       fn parse(&mut self, input: Input) -> IResult<Input, ( $($ty),+ ), Error> {
-        tuple_trait_inner!(0, self, input, (), $($name)+)
-
+        impl_tuple_inner!(0, self, input, (), $($name)+)
       }
     }
   );
 );
 
-macro_rules! tuple_trait_inner(
+macro_rules! impl_tuple_inner(
   ($it:tt, $self:expr, $input:expr, (), $head:ident $($id:ident)+) => ({
     let (i, o) = $self.$it.parse($input.clone())?;
 
-    succ!($it, tuple_trait_inner!($self, i, ( o ), $($id)+))
+    succ!($it, impl_tuple_inner!($self, i, ( o ), $($id)+))
   });
   ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $head:ident $($id:ident)+) => ({
     let (i, o) = $self.$it.parse($input.clone())?;
 
-    succ!($it, tuple_trait_inner!($self, i, ($($parsed)* , o), $($id)+))
+    succ!($it, impl_tuple_inner!($self, i, ($($parsed)* , o), $($id)+))
   });
   ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $head:ident) => ({
     let (i, o) = $self.$it.parse($input.clone())?;
@@ -266,12 +265,12 @@ macro_rules! tuple_trait(
     tuple_trait!(__impl $name1 $ty1, $name2 $ty2; $($name $ty),*);
   );
   (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident, $($name2:ident $ty2:ident),*) => (
-    tuple_trait_impl!($($name $ty),+);
+    impl_tuple!($($name $ty),+);
     tuple_trait!(__impl $($name $ty),+ , $name1 $ty1; $($name2 $ty2),*);
   );
   (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident) => (
-    tuple_trait_impl!($($name $ty),+);
-    tuple_trait_impl!($($name $ty),+, $name1 $ty1);
+    impl_tuple!($($name $ty),+);
+    impl_tuple!($($name $ty),+, $name1 $ty1);
   );
 );
 

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -87,7 +87,7 @@ fn complete() {
 #[test]
 fn pair_test() {
   fn pair_abc_def(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-    pair(tag("abc"), tag("def"))(i)
+    pair(tag("abc"), tag("def")).parse(i)
   }
 
   assert_eq!(
@@ -119,7 +119,7 @@ fn pair_test() {
 #[test]
 fn separated_pair_test() {
   fn sep_pair_abc_def(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-    separated_pair(tag("abc"), tag(","), tag("def"))(i)
+    separated_pair(tag("abc"), tag(","), tag("def")).parse(i)
   }
 
   assert_eq!(
@@ -151,7 +151,7 @@ fn separated_pair_test() {
 #[test]
 fn preceded_test() {
   fn preceded_abcd_efgh(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    preceded(tag("abcd"), tag("efgh"))(i)
+    preceded(tag("abcd"), tag("efgh")).parse(i)
   }
 
   assert_eq!(
@@ -183,7 +183,7 @@ fn preceded_test() {
 #[test]
 fn terminated_test() {
   fn terminated_abcd_efgh(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    terminated(tag("abcd"), tag("efgh"))(i)
+    terminated(tag("abcd"), tag("efgh")).parse(i)
   }
 
   assert_eq!(
@@ -215,7 +215,7 @@ fn terminated_test() {
 #[test]
 fn delimited_test() {
   fn delimited_abc_def_ghi(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    delimited(tag("abc"), tag("def"), tag("ghi"))(i)
+    delimited(tag("abc"), tag("def"), tag("ghi")).parse(i)
   }
 
   assert_eq!(

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::bytes::streaming::{tag, take};
-use crate::error::{ErrorKind, Error};
+use crate::error::{Error, ErrorKind};
 use crate::internal::{Err, IResult, Needed};
 use crate::number::streaming::be_u16;
 
@@ -72,8 +72,8 @@ fn error_to_string<P: Clone + PartialEq>(e: &Context<P, u32>) -> &'static str {
 fn complete() {
   use crate::bytes::complete::tag;
   fn err_test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    let (i, _) = tag("ijkl")(i)?;
-    tag("mnop")(i)
+    let (i, _) = tag("ijkl").parse(i)?;
+    tag("mnop").parse(i)
   }
   let a = &b"ijklmn"[..];
 
@@ -275,7 +275,16 @@ fn tuple_test() {
 
 #[test]
 fn unit_type() {
-  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())("abxsbsh"), Ok(("abxsbsh", ())));
-  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())("sdfjakdsas"), Ok(("sdfjakdsas", ())));
-  assert_eq!(tuple::<&'static str, (), Error<&'static str>, ()>(())(""), Ok(("", ())));
+  assert_eq!(
+    tuple::<&'static str, (), Error<&'static str>, ()>(())("abxsbsh"),
+    Ok(("abxsbsh", ()))
+  );
+  assert_eq!(
+    tuple::<&'static str, (), Error<&'static str>, ()>(())("sdfjakdsas"),
+    Ok(("sdfjakdsas", ()))
+  );
+  assert_eq!(
+    tuple::<&'static str, (), Error<&'static str>, ()>(())(""),
+    Ok(("", ()))
+  );
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -13,7 +13,7 @@ mod test {
     const INPUT: &str = "Hello World!";
     const TAG: &str = "Hello";
     fn test(input: &str) -> IResult<&str, &str> {
-      tag(TAG)(input)
+      tag(TAG).parse(input)
     }
 
     match test(INPUT) {
@@ -60,7 +60,7 @@ mod test {
     const INPUT: &str = "Hello World!";
     const TAG: &str = "Random"; // TAG must be closer than INPUT.
 
-    let res: IResult<_, _, error::Error<_>> = tag(TAG)(INPUT);
+    let res: IResult<_, _, error::Error<_>> = tag(TAG).parse(INPUT);
     match res {
       Err(Err::Error(_)) => (),
       other => {
@@ -78,7 +78,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřèÂßÇ";
     const LEFTOVER: &str = "áƒƭèř";
 
-    let res: IResult<_, _, error::Error<_>> = take(9_usize)(INPUT);
+    let res: IResult<_, _, error::Error<_>> = take(9_usize).parse(INPUT);
     match res {
       Ok((extra, output)) => {
         assert!(
@@ -108,7 +108,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřè";
     const LEFTOVER: &str = "ÂßÇ∂áƒƭèř";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(INPUT);
+    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND).parse(INPUT);
     match res {
       Ok((extra, output)) => {
         assert!(
@@ -204,7 +204,7 @@ mod test {
       c == 'á'
     }
     fn test(input: &str) -> IResult<&str, &str> {
-      take_till(till_s)(input)
+      take_till(till_s).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -239,7 +239,7 @@ mod test {
       c == '9'
     }
     fn test(input: &str) -> IResult<&str, &str> {
-      take_while(while_s)(input)
+      take_while(while_s).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -270,7 +270,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřèÂßÇ";
     const LEFTOVER: &str = "áƒƭèř";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_not(AVOID)(input)
+      is_not(AVOID).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -313,7 +313,7 @@ mod test {
         || c == 'Ç'
     }
     fn test(input: &str) -> IResult<&str, &str> {
-      take_while(while_s)(input)
+      take_while(while_s).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -342,7 +342,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &str = "βúçƙ¥";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_not(AVOID)(input)
+      is_not(AVOID).parse(input)
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
@@ -372,7 +372,7 @@ mod test {
         || c == 'Ç'
     }
     fn test(input: &str) -> IResult<&str, &str> {
-      take_while1(while1_s)(input)
+      take_while1(while1_s).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -421,7 +421,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřèÂßÇ";
     const LEFTOVER: &str = "áƒƭèř";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_a(MATCH)(input)
+      is_a(MATCH).parse(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -454,7 +454,7 @@ mod test {
       c == '9'
     }
     fn test(input: &str) -> IResult<&str, &str> {
-      take_while1(while1_s)(input)
+      take_while1(while1_s).parse(input)
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
@@ -471,7 +471,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &str = "Ûñℓúçƙ¥";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_a(MATCH)(input)
+      is_a(MATCH).parse(input)
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),
@@ -517,7 +517,7 @@ mod test {
   #[test]
   fn utf8_indexing() {
     fn dot(i: &str) -> IResult<&str, &str> {
-      tag(".")(i)
+      tag(".").parse(i)
     }
 
     let _ = dot("點");
@@ -527,7 +527,7 @@ mod test {
   #[test]
   fn case_insensitive() {
     fn test(i: &str) -> IResult<&str, &str> {
-      tag_no_case("ABcd")(i)
+      tag_no_case("ABcd").parse(i)
     }
     assert_eq!(test("aBCdefgh"), Ok(("efgh", "aBCd")));
     assert_eq!(test("abcdefgh"), Ok(("efgh", "abcd")));

--- a/src/str.rs
+++ b/src/str.rs
@@ -42,7 +42,7 @@ mod test {
     const INPUT: &str = "Hello";
     const TAG: &str = "Hello World!";
 
-    let res: IResult<_, _, error::Error<_>> = tag(TAG)(INPUT);
+    let res: IResult<_, _, error::Error<_>> = tag(TAG).parse(INPUT);
     match res {
       Err(Err::Incomplete(_)) => (),
       other => {
@@ -139,7 +139,7 @@ mod test {
 
     const INPUT: &str = "βèƒôřèÂßÇá";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take(13_usize)(INPUT);
+    let res: IResult<_, _, (_, ErrorKind)> = take(13_usize).parse(INPUT);
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(
@@ -161,7 +161,7 @@ mod test {
     use crate::bytes::streaming::take_while;
 
     fn f(i: &str) -> IResult<&str, &str> {
-      take_while(is_alphabetic)(i)
+      take_while(is_alphabetic).parse(i)
     }
     let a = "";
     let b = "abcd";
@@ -179,7 +179,7 @@ mod test {
     use crate::bytes::streaming::take_while1;
 
     fn f(i: &str) -> IResult<&str, &str> {
-      take_while1(is_alphabetic)(i)
+      take_while1(is_alphabetic).parse(i)
     }
     let a = "";
     let b = "abcd";
@@ -403,7 +403,7 @@ mod test {
     const INPUT: &str = "βèƒôřè";
     const FIND: &str = "βèƒôřèÂßÇ";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(INPUT);
+    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND).parse(INPUT);
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(
@@ -489,7 +489,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const FIND: &str = "Ráñδô₥";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(INPUT);
+    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND).parse(INPUT);
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
 fn parens(i: &str) -> IResult<&str, i64> {
-  delimited(space, delimited(tag("("), expr, tag(")")), space)(i)
+  delimited(space, delimited(tag("("), expr, tag(")")), space).parse(i)
 }
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -26,7 +26,8 @@ fn factor(i: &str) -> IResult<&str, i64> {
   alt((
     map_res(delimited(space, digit, space), FromStr::from_str),
     parens,
-  ))(i)
+  ))
+  .parse(i)
 }
 
 // We read an initial factor and for each time we find

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -63,7 +63,8 @@ fn parens(i: &str) -> IResult<&str, Expr> {
     multispace,
     delimited(tag("("), map(expr, |e| Expr::Paren(Box::new(e))), tag(")")),
     multispace,
-  )(i)
+  )
+  .parse(i)
 }
 
 fn factor(i: &str) -> IResult<&str, Expr> {
@@ -93,11 +94,11 @@ fn term(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = factor(i)?;
   let (i, remainder) = many0(alt((
     |i| {
-      let (i, mul) = preceded(tag("*"), factor)(i)?;
+      let (i, mul) = preceded(tag("*"), factor).parse(i)?;
       Ok((i, (Oper::Mul, mul)))
     },
     |i| {
-      let (i, div) = preceded(tag("/"), factor)(i)?;
+      let (i, div) = preceded(tag("/"), factor).parse(i)?;
       Ok((i, (Oper::Div, div)))
     },
   )))(i)?;
@@ -109,11 +110,11 @@ fn expr(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = term(i)?;
   let (i, remainder) = many0(alt((
     |i| {
-      let (i, add) = preceded(tag("+"), term)(i)?;
+      let (i, add) = preceded(tag("+"), term).parse(i)?;
       Ok((i, (Oper::Add, add)))
     },
     |i| {
-      let (i, sub) = preceded(tag("-"), term)(i)?;
+      let (i, sub) = preceded(tag("-"), term).parse(i)?;
       Ok((i, (Oper::Sub, sub)))
     },
   )))(i)?;

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -73,7 +73,8 @@ fn factor(i: &str) -> IResult<&str, Expr> {
       Expr::Value,
     ),
     parens,
-  ))(i)
+  ))
+  .parse(i)
 }
 
 fn fold_exprs(initial: Expr, remainder: Vec<(Oper, Expr)>) -> Expr {

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -24,7 +24,7 @@ fn hex_primary(input: &str) -> IResult<&str, u8> {
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
   let (input, _) = tag("#").parse(input)?;
-  let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+  let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary)).parse(input)?;
 
   Ok((input, Color { red, green, blue }))
 }

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -23,7 +23,7 @@ fn hex_primary(input: &str) -> IResult<&str, u8> {
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
-  let (input, _) = tag("#")(input)?;
+  let (input, _) = tag("#").parse(input)?;
   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
 
   Ok((input, Color { red, green, blue }))

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -30,7 +30,7 @@ impl<'a> ParseError<&'a str> for CustomError {
 
 fn test1(input: &str) -> IResult<&str, &str, CustomError> {
   //fix_error!(input, CustomError, tag!("abcd"))
-  tag("abcd")(input)
+  tag("abcd").parse(input)
 }
 
 fn test2(input: &str) -> IResult<&str, &str, CustomError> {

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -35,7 +35,7 @@ fn test1(input: &str) -> IResult<&str, &str, CustomError> {
 
 fn test2(input: &str) -> IResult<&str, &str, CustomError> {
   //terminated!(input, test1, fix_error!(CustomError, digit))
-  terminated(test1, digit)(input)
+  terminated(test1, digit).parse(input)
 }
 
 fn test3(input: &str) -> IResult<&str, &str, CustomError> {

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -4,13 +4,13 @@ use nom::character::complete::one_of;
 use nom::{error::ErrorKind, Err, IResult};
 
 fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
-  escaped(digit1, '\\', one_of("\"n\\"))(s)
+  escaped(digit1, '\\', one_of("\"n\\")).parse(s)
 }
 
 #[cfg(feature = "alloc")]
 fn esc_trans(s: &str) -> IResult<&str, String, (&str, ErrorKind)> {
   use nom::bytes::complete::{escaped_transform, tag};
-  escaped_transform(digit1, '\\', tag("n"))(s)
+  escaped_transform(digit1, '\\', tag("n")).parse(s)
 }
 
 #[test]

--- a/tests/fnmut.rs
+++ b/tests/fnmut.rs
@@ -10,7 +10,7 @@ fn parse() {
   let res = {
     let mut parser = many0::<_, _, (), _>(|i| {
       counter += 1;
-      tag("abc")(i)
+      tag("abc").parse(i)
     });
 
     parser("abcabcabcabc").unwrap()
@@ -26,7 +26,7 @@ fn accumulate() {
 
   let (_, count) = {
     let mut parser = many0_count::<_, _, (), _>(|i| {
-      let (i, o) = tag("abc")(i)?;
+      let (i, o) = tag("abc").parse(i)?;
       v.push(o);
       Ok((i, ()))
     });

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -30,7 +30,8 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 fn keys_and_values(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
   map(many0(terminated(key_value, opt(multispace))), |vec| {
     vec.into_iter().collect()
-  })(i)
+  })
+  .parse(i)
 }
 
 fn category_and_keys(i: &[u8]) -> IResult<&[u8], (&str, HashMap<&str, &str>)> {
@@ -50,7 +51,8 @@ fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
       ),
     )),
     |vec: Vec<_>| vec.into_iter().collect(),
-  )(i)
+  )
+  .parse(i)
 }
 
 #[test]

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -21,7 +21,7 @@ fn category(i: &[u8]) -> IResult<&[u8], &str> {
 
 fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
   let (i, key) = map_res(alphanumeric, str::from_utf8)(i)?;
-  let (i, _) = tuple((opt(space), char('='), opt(space)))(i)?;
+  let (i, _) = tuple((opt(space), char('='), opt(space))).parse(i)?;
   let (i, val) = map_res(take_while(|c| c != b'\n' && c != b';'), str::from_utf8)(i)?;
   let (i, _) = opt(pair(char(';'), take_while(|c| c != b'\n')))(i)?;
   Ok((i, (key, val)))

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -34,7 +34,7 @@ fn keys_and_values(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
 }
 
 fn category_and_keys(i: &[u8]) -> IResult<&[u8], (&str, HashMap<&str, &str>)> {
-  let (i, category) = terminated(category, opt(multispace))(i)?;
+  let (i, category) = terminated(category, opt(multispace)).parse(i)?;
   let (i, keys) = keys_and_values(i)?;
   Ok((i, (category, keys)))
 }

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -30,7 +30,7 @@ fn category(i: &str) -> IResult<&str, &str> {
 
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
-  let (i, _) = tuple((opt(space), tag("="), opt(space)))(i)?;
+  let (i, _) = tuple((opt(space), tag("="), opt(space))).parse(i)?;
   let (i, val) = take_till(is_line_ending_or_comment).parse(i)?;
   let (i, _) = opt(space)(i)?;
   let (i, _) = opt(pair(tag(";"), not_line_ending))(i)?;

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -25,7 +25,8 @@ fn category(i: &str) -> IResult<&str, &str> {
   terminated(
     delimited(char('['), take_while(|c| c != ']'), char(']')),
     opt(is_a(" \r\n")),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
@@ -51,7 +52,7 @@ fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
 }
 
 fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
-  pair(category, keys_and_values)(i)
+  pair(category, keys_and_values).parse(i)
 }
 
 fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -14,11 +14,11 @@ fn is_line_ending_or_comment(chr: char) -> bool {
 }
 
 fn not_line_ending(i: &str) -> IResult<&str, &str> {
-  take_while(|c| c != '\r' && c != '\n')(i)
+  take_while(|c| c != '\r' && c != '\n').parse(i)
 }
 
 fn space_or_line_ending(i: &str) -> IResult<&str, &str> {
-  is_a(" \r\n")(i)
+  is_a(" \r\n").parse(i)
 }
 
 fn category(i: &str) -> IResult<&str, &str> {
@@ -31,7 +31,7 @@ fn category(i: &str) -> IResult<&str, &str> {
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
   let (i, _) = tuple((opt(space), tag("="), opt(space)))(i)?;
-  let (i, val) = take_till(is_line_ending_or_comment)(i)?;
+  let (i, val) = take_till(is_line_ending_or_comment).parse(i)?;
   let (i, _) = opt(space)(i)?;
   let (i, _) = opt(pair(tag(";"), not_line_ending))(i)?;
   let (i, _) = opt(space_or_line_ending)(i)?;

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -74,7 +74,7 @@ fn take_till_issue() {
   use nom::bytes::streaming::take_till;
 
   fn nothing(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_till(|_| true)(i)
+    take_till(|_| true).parse(i)
   }
 
   assert_eq!(nothing(b""), Err(Err::Incomplete(Needed::new(1))));
@@ -129,7 +129,7 @@ mod issue_647 {
 
   fn data(input: Input<'_>) -> IResult<Input<'_>, Data> {
     let (i, c) = be_f64(input)?;
-    let (i, _) = tag("\n")(i)?;
+    let (i, _) = tag("\n").parse(i)?;
     let (i, v) = list(i, &c)?;
     Ok((i, Data { c, v }))
   }
@@ -139,7 +139,7 @@ mod issue_647 {
 fn issue_848_overflow_incomplete_bits_to_bytes() {
   fn take(i: &[u8]) -> IResult<&[u8], &[u8]> {
     use nom::bytes::streaming::take;
-    take(0x2000000000000000_usize)(i)
+    take(0x2000000000000000_usize).parse(i)
   }
   fn parser(i: &[u8]) -> IResult<&[u8], &[u8]> {
     use nom::bits::{bits, bytes};

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -144,7 +144,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
   fn parser(i: &[u8]) -> IResult<&[u8], &[u8]> {
     use nom::bits::{bits, bytes};
 
-    bits(bytes(take))(i)
+    bits(bytes(take)).parse(i)
   }
   assert_eq!(
     parser(&b""[..]),
@@ -202,7 +202,7 @@ fn issue_1231_bits_expect_fn_closure() {
   use nom::error::Error;
   use nom::sequence::tuple;
   pub fn example(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
-    bits::<_, _, Error<_>, _, _>(tuple((take(1usize), take(1usize))))(input)
+    bits::<_, Error<_>, _, _, _>(tuple((take(1usize), take(1usize)))).parse(input)
   }
   assert_eq!(example(&[0xff]), Ok((&b""[..], (1, 1))));
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -183,7 +183,7 @@ fn issue_1027_convert_error_panic_nonempty() {
 
   let input = "a";
 
-  let result: IResult<_, _, VerboseError<&str>> = pair(char('a'), char('b'))(input);
+  let result: IResult<_, _, VerboseError<&str>> = pair(char('a'), char('b')).parse(input);
   let err = match result.unwrap_err() {
     Err::Error(e) => e,
     _ => unreachable!(),

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -25,7 +25,7 @@ pub enum JsonValue {
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
-  alt((value(false, tag("false")), value(true, tag("true"))))(input)
+  alt((value(false, tag("false")), value(true, tag("true")))).parse(input)
 }
 
 fn u16_hex(input: &str) -> IResult<&str, u16> {
@@ -73,7 +73,8 @@ fn character(input: &str) -> IResult<&str, char> {
         })
       }),
       preceded(char('u'), unicode_escape),
-    ))(input)
+    ))
+    .parse(input)
   } else {
     Ok((input, c))
   }
@@ -126,7 +127,8 @@ fn json_value(input: &str) -> IResult<&str, JsonValue> {
     map(double, Num),
     map(array, Array),
     map(object, Object),
-  ))(input)
+  ))
+  .parse(input)
 }
 
 fn json(input: &str) -> IResult<&str, JsonValue> {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -116,7 +116,8 @@ fn object(input: &str) -> IResult<&str, HashMap<String, JsonValue>> {
       char('}'),
     ),
     |key_values| key_values.into_iter().collect(),
-  )(input)
+  )
+  .parse(input)
 }
 
 fn json_value(input: &str) -> IResult<&str, JsonValue> {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -88,7 +88,8 @@ fn string(input: &str) -> IResult<&str, String> {
       string
     }),
     char('"'),
-  )(input)
+  )
+  .parse(input)
 }
 
 fn ws<'a, O, E: ParseError<&'a str>, F: Parser<&'a str, O, E>>(f: F) -> impl Parser<&'a str, O, E> {
@@ -100,7 +101,8 @@ fn array(input: &str) -> IResult<&str, Vec<JsonValue>> {
     char('['),
     ws(separated_list0(ws(char(',')), json_value)),
     char(']'),
-  )(input)
+  )
+  .parse(input)
 }
 
 fn object(input: &str) -> IResult<&str, HashMap<String, JsonValue>> {

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -287,7 +287,8 @@ fn box_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
     map(tag("skip"), |_| MP4BoxType::Skip),
     map(tag("wide"), |_| MP4BoxType::Wide),
     unknown_box_type,
-  ))(input)
+  ))
+  .parse(input)
 }
 
 // warning, an alt combinator with 9 branches containing a tag combinator
@@ -304,7 +305,8 @@ fn moov_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
     map(tag("clip"), |_| MP4BoxType::Clip),
     map(tag("trak"), |_| MP4BoxType::Trak),
     map(tag("udta"), |_| MP4BoxType::Udta),
-  ))(input)
+  ))
+  .parse(input)
 }
 
 fn box_header(input: &[u8]) -> IResult<&[u8], MP4BoxHeader> {

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -103,7 +103,7 @@ fn mvhd32(i: &[u8]) -> IResult<&[u8], MvhdBox> {
   let (i, duration) =      be_u32(i)?;
   let (i, speed) =         be_f32(i)?;
   let (i, volume) =        be_u16(i)?; // actually a 2 bytes decimal
-  let (i, _) =             take(10_usize)(i)?;
+  let (i, _) =             take(10_usize).parse(i)?;
   let (i, scale_a) =       be_f32(i)?;
   let (i, rotate_b) =      be_f32(i)?;
   let (i, angle_u) =       be_f32(i)?;
@@ -155,7 +155,7 @@ fn mvhd64(i: &[u8]) -> IResult<&[u8], MvhdBox> {
   let (i, duration) =      be_u64(i)?;
   let (i, speed) =         be_f32(i)?;
   let (i, volume) =        be_u16(i)?; // actually a 2 bytes decimal
-  let (i, _) =             take(10_usize)(i)?;
+  let (i, _) =             take(10_usize).parse(i)?;
   let (i, scale_a) =       be_f32(i)?;
   let (i, rotate_b) =      be_f32(i)?;
   let (i, angle_u) =       be_f32(i)?;
@@ -249,7 +249,7 @@ fn brand_name(input: &[u8]) -> IResult<&[u8], &str> {
 
 fn filetype_parser(input: &[u8]) -> IResult<&[u8], FileType<'_>> {
   let (i, name) = brand_name(input)?;
-  let (i, version) = take(4_usize)(i)?;
+  let (i, version) = take(4_usize).parse(i)?;
   let (i, brands) = many0(brand_name)(i)?;
 
   let ft = FileType {

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -14,7 +14,7 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn read_line(input: &str) -> IResult<&str, &str> {
-  terminated(alphanumeric, end_of_line)(input)
+  terminated(alphanumeric, end_of_line).parse(input)
 }
 
 pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -13,7 +13,7 @@ use nom::{Err, IResult, Needed};
 
 // We request a length that would trigger an overflow if computing consumed + requested
 fn parser02(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-  tuple((take(1_usize), take(18446744073709551615_usize)))(i)
+  tuple((take(1_usize), take(18446744073709551615_usize))).parse(i)
 }
 
 #[test]

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -27,5 +27,6 @@ fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> IResult<&'a [u8], String> {
       acc + next.as_str()
     }),
     char(')'),
-  )(i)
+  )
+  .parse(i)
 }


### PR DESCRIPTION
This switches nom parsers to returning concrete types that implement `Parser`, rather than opaque `FnMut`s.  This unblocks having the parser functions return types that implement two different parser traits for Geal/nom#1535.

Other benefits
- Improved the consistency of parsers taking `Parser`, rather than `FnMut`
- Implemented `Parser` for tuples (Geal/nom#1417)
- More consistency across parsers

BREAKING CHANGES:
- Parsers no longer return functions but concrete types
- Order of generic parameters for parsers is now more consistent