### PR TITLE
fix(input): Associate Partial trat with Streaming 

### DIFF
--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -4,7 +4,7 @@ use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
   Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
-  InputTakeAtPositionPartial, Slice, ToUsize,
+  InputTakeAtPositionStreaming, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::*;
@@ -118,12 +118,12 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  T: FindToken<<Input as InputTakeAtPositionPartial>::Item>,
+  Input: InputTakeAtPositionStreaming,
+  T: FindToken<<Input as InputTakeAtPositionStreaming>::Item>,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsNot;
-    i.split_at_position1_partial(|c| arr.find_token(c), e)
+    i.split_at_position1_streaming(|c| arr.find_token(c), e)
   }
 }
 
@@ -154,12 +154,12 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  T: FindToken<<Input as InputTakeAtPositionPartial>::Item>,
+  Input: InputTakeAtPositionStreaming,
+  T: FindToken<<Input as InputTakeAtPositionStreaming>::Item>,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsA;
-    i.split_at_position1_partial(|c| !arr.find_token(c), e)
+    i.split_at_position1_streaming(|c| !arr.find_token(c), e)
   }
 }
 
@@ -189,10 +189,10 @@ pub fn take_while<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  F: Fn(<Input as InputTakeAtPositionPartial>::Item) -> bool,
+  Input: InputTakeAtPositionStreaming,
+  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position_partial(|c| !cond(c))
+  move |i: Input| i.split_at_position_streaming(|c| !cond(c))
 }
 
 /// Returns the longest (at least 1) input slice that matches the predicate.
@@ -223,12 +223,12 @@ pub fn take_while1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  F: Fn(<Input as InputTakeAtPositionPartial>::Item) -> bool,
+  Input: InputTakeAtPositionStreaming,
+  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeWhile1;
-    i.split_at_position1_partial(|c| !cond(c), e)
+    i.split_at_position1_streaming(|c| !cond(c), e)
   }
 }
 
@@ -344,10 +344,10 @@ pub fn take_till<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  F: Fn(<Input as InputTakeAtPositionPartial>::Item) -> bool,
+  Input: InputTakeAtPositionStreaming,
+  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position_partial(|c| cond(c))
+  move |i: Input| i.split_at_position_streaming(|c| cond(c))
 }
 
 /// Returns the longest (at least 1) input slice till a predicate is met.
@@ -376,12 +376,12 @@ pub fn take_till1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionPartial,
-  F: Fn(<Input as InputTakeAtPositionPartial>::Item) -> bool,
+  Input: InputTakeAtPositionStreaming,
+  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeTill1;
-    i.split_at_position1_partial(|c| cond(c), e)
+    i.split_at_position1_streaming(|c| cond(c), e)
   }
 }
 
@@ -532,7 +532,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPositionPartial
+    + InputTakeAtPositionStreaming
     + Slice<RangeFrom<usize>>
     + InputIter,
   <Input as InputIter>::Item: crate::input::AsChar,
@@ -633,7 +633,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPositionPartial
+    + InputTakeAtPositionStreaming
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -7,7 +7,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPositionPartial, Slice,
+  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPositionStreaming, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -316,10 +316,10 @@ where
 /// ```
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position_partial(|item| !item.is_alpha())
+  input.split_at_position_streaming(|item| !item.is_alpha())
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -337,10 +337,10 @@ where
 /// ```
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position1_partial(|item| !item.is_alpha(), ErrorKind::Alpha)
+  input.split_at_position1_streaming(|item| !item.is_alpha(), ErrorKind::Alpha)
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
@@ -358,10 +358,10 @@ where
 /// ```
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position_partial(|item| !item.is_dec_digit())
+  input.split_at_position_streaming(|item| !item.is_dec_digit())
 }
 
 /// Recognizes one or more ASCII numerical characters: 0-9
@@ -379,10 +379,10 @@ where
 /// ```
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position1_partial(|item| !item.is_dec_digit(), ErrorKind::Digit)
+  input.split_at_position1_streaming(|item| !item.is_dec_digit(), ErrorKind::Digit)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -400,10 +400,10 @@ where
 /// ```
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position_partial(|item| !item.is_hex_digit())
+  input.split_at_position_streaming(|item| !item.is_hex_digit())
 }
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -421,10 +421,10 @@ where
 /// ```
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position1_partial(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
+  input.split_at_position1_streaming(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
 }
 
 /// Recognizes zero or more octal characters: 0-7
@@ -442,10 +442,10 @@ where
 /// ```
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position_partial(|item| !item.is_oct_digit())
+  input.split_at_position_streaming(|item| !item.is_oct_digit())
 }
 
 /// Recognizes one or more octal characters: 0-7
@@ -463,10 +463,10 @@ where
 /// ```
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position1_partial(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
+  input.split_at_position1_streaming(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -484,10 +484,10 @@ where
 /// ```
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position_partial(|item| !item.is_alphanum())
+  input.split_at_position_streaming(|item| !item.is_alphanum())
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -505,10 +505,10 @@ where
 /// ```
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
-  input.split_at_position1_partial(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
+  input.split_at_position1_streaming(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -526,10 +526,10 @@ where
 /// ```
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar + Clone,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
 {
-  input.split_at_position_partial(|item| {
+  input.split_at_position_streaming(|item| {
     let c = item.as_char();
     !(c == ' ' || c == '\t')
   })
@@ -549,10 +549,10 @@ where
 /// ```
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar + Clone,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
 {
-  input.split_at_position1_partial(
+  input.split_at_position1_streaming(
     |item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t')
@@ -576,10 +576,10 @@ where
 /// ```
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar + Clone,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
 {
-  input.split_at_position_partial(|item| {
+  input.split_at_position_streaming(|item| {
     let c = item.as_char();
     !(c == ' ' || c == '\t' || c == '\r' || c == '\n')
   })
@@ -600,10 +600,10 @@ where
 /// ```
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar + Clone,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
 {
-  input.split_at_position1_partial(
+  input.split_at_position1_streaming(
     |item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t' || c == '\r' || c == '\n')

--- a/src/input.rs
+++ b/src/input.rs
@@ -25,19 +25,19 @@
 //!
 //! | trait | usage |
 //! |---|---|
-//! | [AsBytes][AsBytes] |Casts the input type to a byte slice|
-//! | [Compare][Compare] |Character comparison operations|
-//! | [ExtendInto][ExtendInto] |Abstracts something which can extend an `Extend`|
-//! | [FindSubstring][FindSubstring] |Look for a substring in self|
-//! | [FindToken][FindToken] |Look for self in the given input stream|
-//! | [InputIter][InputIter] |Common iteration operations on the input type|
-//! | [InputLength][InputLength] |Calculate the input length|
-//! | [InputTake][InputTake] |Slicing operations|
-//! | [InputTakeAtPosition][InputTakeAtPosition] |Look for a specific token and split at its position|
+//! | [AsBytes] |Casts the input type to a byte slice|
+//! | [Compare] |Character comparison operations|
+//! | [ExtendInto] |Abstracts something which can extend an `Extend`|
+//! | [FindSubstring] |Look for a substring in self|
+//! | [FindToken] |Look for self in the given input stream|
+//! | [InputIter] |Common iteration operations on the input type|
+//! | [InputLength] |Calculate the input length|
+//! | [InputTake] |Slicing operations|
+//! | [InputTakeAtPosition] |Look for a specific token and split at its position|
 //! | [InputTakeAtPositionStreaming] |Look for a specific token and split at its position|
-//! | [Offset][Offset] |Calculate the offset between slices|
-//! | [ParseTo][ParseTo] |Used to integrate `&str`'s `parse()` method|
-//! | [Slice][Slice] |Slicing operations using ranges|
+//! | [Offset] |Calculate the offset between slices|
+//! | [ParseTo] |Used to integrate `&str`'s `parse()` method|
+//! | [Slice] |Slicing operations using ranges|
 //!
 //! Here are the traits we have to implement for `MyItem`:
 //!

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -6,8 +6,8 @@ use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPositionPartial, Offset,
-  Slice,
+  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPositionStreaming,
+  Offset, Slice,
 };
 use crate::lib::std::ops::{RangeFrom, RangeTo};
 use crate::sequence::{pair, tuple};
@@ -1371,8 +1371,8 @@ where
   T: Clone + Offset,
   T: InputIter,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionPartial + InputLength,
-  <T as InputTakeAtPositionPartial>::Item: AsChar
+  T: InputTakeAtPositionStreaming + InputLength,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar
 {
   recognize(
     tuple((
@@ -1398,8 +1398,8 @@ where
   T: Clone + Offset,
   T: InputIter + InputTake + InputLength + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
 {
   alt((
     |i: T| {
@@ -1437,14 +1437,14 @@ where
   T: Clone + Offset,
   T: InputIter + crate::input::ParseTo<i32>,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionPartial + InputTake + InputLength,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming + InputTake + InputLength,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
 {
   let (i, sign) = sign(input.clone())?;
 
-  //let (i, zeroes) = take_while(|c: <T as InputTakeAtPositionPartial>::Item| c.as_char() == '0')(i)?;
+  //let (i, zeroes) = take_while(|c: <T as InputTakeAtPositionStreaming>::Item| c.as_char() == '0')(i)?;
   let (i, zeroes) = match i.as_bytes().iter().position(|c| *c != b'0') {
     Some(index) => i.take_split(index),
     None => i.take_split(i.input_len()),
@@ -1547,8 +1547,8 @@ where
   T: InputIter + InputLength + InputTake + crate::input::ParseTo<f32> + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1601,8 +1601,8 @@ where
   T: InputIter + InputLength + InputTake + crate::input::ParseTo<f64> + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPositionPartial,
-  <T as InputTakeAtPositionPartial>::Item: AsChar,
+  T: InputTakeAtPositionStreaming,
+  <T as InputTakeAtPositionStreaming>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {


### PR DESCRIPTION
In #3, I split the `InputSplitAtPosition` trait but I named it for the
naming direction I assumed I was going.  I've backed off from that and
am naming it to match everything else, for now.