### PR TITLE
fix(parser): Clarify FinishIResult extends IResult

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! use nom::{
 //!   IResult,
-//!   Finish,
+//!   FinishIResult as _,
 //!   bytes::complete::{tag, take_while_m_n},
 //!   combinator::map_res,
 //!   sequence::tuple,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,10 @@
 //! ## Example
 //!
 //! ```rust
-//! use nom::{
-//!   IResult,
-//!   FinishIResult as _,
-//!   bytes::complete::{tag, take_while_m_n},
-//!   combinator::map_res,
-//!   sequence::tuple,
-//! };
+//! use nom::prelude::*;
+//! use nom::bytes::complete::{tag, take_while_m_n};
+//! use nom::combinator::map_res;
+//! use nom::sequence::tuple;
 //!
 //! #[derive(Debug,PartialEq)]
 //! pub struct Color {
@@ -466,3 +463,30 @@ pub mod number;
 pub mod _cookbook;
 #[cfg(feature = "unstable-doc")]
 pub mod _tutorial;
+
+/// Core concepts available for glob import
+///
+/// Including
+/// - [`FinishIResult`]
+/// - [`Parser`]
+///
+/// ## Example
+///
+/// ```rust
+/// use nom::prelude::*;
+///
+/// fn parse_data(input: &str) -> IResult<&str, u64> {
+///     // ...
+/// #   nom::character::complete::u64(input)
+/// }
+///
+/// fn main() {
+///   let result = parse_data.parse("100").finish();
+///   assert_eq!(result, Ok(("", 100)));
+/// }
+/// ```
+pub mod prelude {
+  pub use crate::FinishIResult as _;
+  pub use crate::IResult;
+  pub use crate::Parser as _;
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,7 +49,10 @@ impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E> {
 }
 
 #[doc(hidden)]
-#[deprecated(since = "8.0.0", note = "Replaced with `FinishIResult")]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `FinishIResult` which is available via `nom::prelude`"
+)]
 pub trait Finish<I, O, E> {
   fn finish(self) -> Result<(I, O), E>;
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,13 +18,16 @@ use core::num::NonZeroUsize;
 /// it to a more common result type
 pub type IResult<I, O, E = error::Error<I>> = Result<(I, O), Err<E>>;
 
-/// Helper trait to convert a parser's result to a more manageable type
+/// Extension trait to convert a parser's [`IResult`] to a more manageable type
 pub trait Finish<I, O, E> {
-  /// converts the parser's result to a type that is more consumable by error
-  /// management libraries. It keeps the same `Ok` branch, and merges `Err::Error`
-  /// and `Err::Failure` into the `Err` side.
+  /// Converts the parser's [`IResult`] to a type that is more consumable by errors.
   ///
-  /// *warning*: if the result is `Err(Err::Incomplete(_))`, this method will panic.
+  ///  It keeps the same `Ok` branch, and merges `Err::Error` and `Err::Failure` into the `Err`
+  ///  side.
+  ///
+  /// # Panic
+  ///
+  /// If the result is `Err(Err::Incomplete(_))`, this method will panic.
   /// - "complete" parsers: It will not be an issue, `Incomplete` is never used
   /// - "streaming" parsers: `Incomplete` will be returned if there's not enough data
   /// for the parser to decide, and you should gather more data before parsing again.


### PR DESCRIPTION
`Finish` has no purpose out of extending `IResult`, so this makes that clearer.  I went ahead and left off the `Ext` suffix.

To make this even easier to discover, I advertise it as part of a new `prelude`.