### PR TITLE
fix: Deprecate character::is_* functions

### DIFF
--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -8,109 +8,51 @@ mod tests;
 pub mod complete;
 pub mod streaming;
 
-/// Tests if byte is ASCII alphabetic: A-Z, a-z
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_alphabetic;
-/// assert_eq!(is_alphabetic(b'9'), false);
-/// assert_eq!(is_alphabetic(b'a'), true);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_alpha`")]
 pub fn is_alphabetic(chr: u8) -> bool {
   (chr >= 0x41 && chr <= 0x5A) || (chr >= 0x61 && chr <= 0x7A)
 }
 
-/// Tests if byte is ASCII digit: 0-9
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_digit;
-/// assert_eq!(is_digit(b'a'), false);
-/// assert_eq!(is_digit(b'9'), true);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_dec_digit`")]
 pub fn is_digit(chr: u8) -> bool {
   chr >= 0x30 && chr <= 0x39
 }
 
-/// Tests if byte is ASCII hex digit: 0-9, A-F, a-f
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_hex_digit;
-/// assert_eq!(is_hex_digit(b'a'), true);
-/// assert_eq!(is_hex_digit(b'9'), true);
-/// assert_eq!(is_hex_digit(b'A'), true);
-/// assert_eq!(is_hex_digit(b'x'), false);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_hex_digit`")]
 pub fn is_hex_digit(chr: u8) -> bool {
   (chr >= 0x30 && chr <= 0x39) || (chr >= 0x41 && chr <= 0x46) || (chr >= 0x61 && chr <= 0x66)
 }
 
-/// Tests if byte is ASCII octal digit: 0-7
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_oct_digit;
-/// assert_eq!(is_oct_digit(b'a'), false);
-/// assert_eq!(is_oct_digit(b'9'), false);
-/// assert_eq!(is_oct_digit(b'6'), true);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_oct_digit`")]
 pub fn is_oct_digit(chr: u8) -> bool {
   chr >= 0x30 && chr <= 0x37
 }
 
-/// Tests if byte is ASCII alphanumeric: A-Z, a-z, 0-9
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_alphanumeric;
-/// assert_eq!(is_alphanumeric(b'-'), false);
-/// assert_eq!(is_alphanumeric(b'a'), true);
-/// assert_eq!(is_alphanumeric(b'9'), true);
-/// assert_eq!(is_alphanumeric(b'A'), true);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_alphanum`")]
 pub fn is_alphanumeric(chr: u8) -> bool {
   is_alphabetic(chr) || is_digit(chr)
 }
 
-/// Tests if byte is ASCII space or tab
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_space;
-/// assert_eq!(is_space(b'\n'), false);
-/// assert_eq!(is_space(b'\r'), false);
-/// assert_eq!(is_space(b' '), true);
-/// assert_eq!(is_space(b'\t'), true);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_space`")]
 pub fn is_space(chr: u8) -> bool {
   chr == b' ' || chr == b'\t'
 }
 
-/// Tests if byte is ASCII newline: \n
-///
-/// # Example
-///
-/// ```
-/// # use nom::character::is_newline;
-/// assert_eq!(is_newline(b'\n'), true);
-/// assert_eq!(is_newline(b'\r'), false);
-/// assert_eq!(is_newline(b' '), false);
-/// assert_eq!(is_newline(b'\t'), false);
-/// ```
 #[inline]
+#[doc(hidden)]
+#[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_newline`")]
 pub fn is_newline(chr: u8) -> bool {
   chr == b'\n'
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -7,3 +7,110 @@ mod tests;
 
 pub mod complete;
 pub mod streaming;
+
+/// Tests if byte is ASCII alphabetic: A-Z, a-z
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_alphabetic;
+/// assert_eq!(is_alphabetic(b'9'), false);
+/// assert_eq!(is_alphabetic(b'a'), true);
+/// ```
+#[inline]
+pub fn is_alphabetic(chr: u8) -> bool {
+  (chr >= 0x41 && chr <= 0x5A) || (chr >= 0x61 && chr <= 0x7A)
+}
+
+/// Tests if byte is ASCII digit: 0-9
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_digit;
+/// assert_eq!(is_digit(b'a'), false);
+/// assert_eq!(is_digit(b'9'), true);
+/// ```
+#[inline]
+pub fn is_digit(chr: u8) -> bool {
+  chr >= 0x30 && chr <= 0x39
+}
+
+/// Tests if byte is ASCII hex digit: 0-9, A-F, a-f
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_hex_digit;
+/// assert_eq!(is_hex_digit(b'a'), true);
+/// assert_eq!(is_hex_digit(b'9'), true);
+/// assert_eq!(is_hex_digit(b'A'), true);
+/// assert_eq!(is_hex_digit(b'x'), false);
+/// ```
+#[inline]
+pub fn is_hex_digit(chr: u8) -> bool {
+  (chr >= 0x30 && chr <= 0x39) || (chr >= 0x41 && chr <= 0x46) || (chr >= 0x61 && chr <= 0x66)
+}
+
+/// Tests if byte is ASCII octal digit: 0-7
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_oct_digit;
+/// assert_eq!(is_oct_digit(b'a'), false);
+/// assert_eq!(is_oct_digit(b'9'), false);
+/// assert_eq!(is_oct_digit(b'6'), true);
+/// ```
+#[inline]
+pub fn is_oct_digit(chr: u8) -> bool {
+  chr >= 0x30 && chr <= 0x37
+}
+
+/// Tests if byte is ASCII alphanumeric: A-Z, a-z, 0-9
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_alphanumeric;
+/// assert_eq!(is_alphanumeric(b'-'), false);
+/// assert_eq!(is_alphanumeric(b'a'), true);
+/// assert_eq!(is_alphanumeric(b'9'), true);
+/// assert_eq!(is_alphanumeric(b'A'), true);
+/// ```
+#[inline]
+pub fn is_alphanumeric(chr: u8) -> bool {
+  is_alphabetic(chr) || is_digit(chr)
+}
+
+/// Tests if byte is ASCII space or tab
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_space;
+/// assert_eq!(is_space(b'\n'), false);
+/// assert_eq!(is_space(b'\r'), false);
+/// assert_eq!(is_space(b' '), true);
+/// assert_eq!(is_space(b'\t'), true);
+/// ```
+#[inline]
+pub fn is_space(chr: u8) -> bool {
+  chr == b' ' || chr == b'\t'
+}
+
+/// Tests if byte is ASCII newline: \n
+///
+/// # Example
+///
+/// ```
+/// # use nom::character::is_newline;
+/// assert_eq!(is_newline(b'\n'), true);
+/// assert_eq!(is_newline(b'\r'), false);
+/// assert_eq!(is_newline(b' '), false);
+/// assert_eq!(is_newline(b'\t'), false);
+/// ```
+#[inline]
+pub fn is_newline(chr: u8) -> bool {
+  chr == b'\n'
+}


### PR DESCRIPTION
Instead of removing them, like in #2, we'll deprecate them so people have a smoother upgrade path