### PR TITLE
refactor(tests): Move all tests out of mod 

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod complete;
 pub mod streaming;
+#[cfg(test)]
+mod tests;
 
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{ErrorConvert, Slice};
@@ -107,73 +109,5 @@ where
       Err(Err::Error(e)) => Err(Err::Error(e.convert())),
       Err(Err::Failure(e)) => Err(Err::Failure(e.convert())),
     }
-  }
-}
-
-#[cfg(test)]
-mod test {
-  use super::*;
-  use crate::bits::streaming::take;
-  use crate::error::Error;
-  use crate::sequence::tuple;
-
-  #[test]
-  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
-  /// previous bytes are fully consumed
-  fn test_complete_byte_consumption_bits() {
-    let input = &[0x12, 0x34, 0x56, 0x78];
-
-    // Take 3 bit slices with sizes [4, 8, 4].
-    let result: IResult<&[u8], (u8, u8, u8)> =
-      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize), take(4usize))))(
-        input,
-      );
-
-    let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
-
-    let remaining = output.0;
-    assert_eq!(remaining, [0x56, 0x78]);
-
-    let parsed = output.1;
-    assert_eq!(parsed.0, 0x01);
-    assert_eq!(parsed.1, 0x23);
-    assert_eq!(parsed.2, 0x04);
-  }
-
-  #[test]
-  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
-  /// previous bytes are NOT fully consumed. Partially consumed bytes are supposed to be dropped.
-  /// I.e. if we consume 1.5 bytes of 4 bytes, 2 bytes will be returned, bits 13-16 will be
-  /// dropped.
-  fn test_partial_byte_consumption_bits() {
-    let input = &[0x12, 0x34, 0x56, 0x78];
-
-    // Take bit slices with sizes [4, 8].
-    let result: IResult<&[u8], (u8, u8)> =
-      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
-
-    let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
-
-    let remaining = output.0;
-    assert_eq!(remaining, [0x56, 0x78]);
-
-    let parsed = output.1;
-    assert_eq!(parsed.0, 0x01);
-    assert_eq!(parsed.1, 0x23);
-  }
-
-  #[test]
-  #[cfg(feature = "std")]
-  /// Ensure that in Incomplete error is thrown, if too few bytes are passed for a given parser.
-  fn test_incomplete_bits() {
-    let input = &[0x12];
-
-    // Take bit slices with sizes [4, 8].
-    let result: IResult<&[u8], (u8, u8)> =
-      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
-
-    assert!(result.is_err());
-    let error = result.err().unwrap();
-    assert_eq!("Parsing requires 2 bytes/chars", error.to_string());
   }
 }

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -1,0 +1,64 @@
+  use super::*;
+  use crate::bits::streaming::take;
+  use crate::error::Error;
+  use crate::sequence::tuple;
+
+  #[test]
+  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
+  /// previous bytes are fully consumed
+  fn test_complete_byte_consumption_bits() {
+    let input = &[0x12, 0x34, 0x56, 0x78];
+
+    // Take 3 bit slices with sizes [4, 8, 4].
+    let result: IResult<&[u8], (u8, u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize), take(4usize))))(
+        input,
+      );
+
+    let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
+
+    let remaining = output.0;
+    assert_eq!(remaining, [0x56, 0x78]);
+
+    let parsed = output.1;
+    assert_eq!(parsed.0, 0x01);
+    assert_eq!(parsed.1, 0x23);
+    assert_eq!(parsed.2, 0x04);
+  }
+
+  #[test]
+  /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
+  /// previous bytes are NOT fully consumed. Partially consumed bytes are supposed to be dropped.
+  /// I.e. if we consume 1.5 bytes of 4 bytes, 2 bytes will be returned, bits 13-16 will be
+  /// dropped.
+  fn test_partial_byte_consumption_bits() {
+    let input = &[0x12, 0x34, 0x56, 0x78];
+
+    // Take bit slices with sizes [4, 8].
+    let result: IResult<&[u8], (u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+
+    let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
+
+    let remaining = output.0;
+    assert_eq!(remaining, [0x56, 0x78]);
+
+    let parsed = output.1;
+    assert_eq!(parsed.0, 0x01);
+    assert_eq!(parsed.1, 0x23);
+  }
+
+  #[test]
+  #[cfg(feature = "std")]
+  /// Ensure that in Incomplete error is thrown, if too few bytes are passed for a given parser.
+  fn test_incomplete_bits() {
+    let input = &[0x12];
+
+    // Take bit slices with sizes [4, 8].
+    let result: IResult<&[u8], (u8, u8)> =
+      bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert_eq!("Parsing requires 2 bytes/chars", error.to_string());
+  }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -37,6 +37,7 @@ pub fn is_oct_digit(chr: u8) -> bool {
 #[doc(hidden)]
 #[deprecated(since = "8.0.0", note = "Replaced with `AsChar::is_alphanum`")]
 pub fn is_alphanumeric(chr: u8) -> bool {
+  #![allow(deprecated)]
   is_alphabetic(chr) || is_digit(chr)
 }
 


### PR DESCRIPTION
This is prep for merged complete/streaming.

As I expect all `streaming` and `complete` mods to be deprecated, I've
isolated there tests to those mods.  When we add the merged versions,
that'll be too many tests for the `mod.rs` files (and requires more
recompilation), so I'm moving these out to tests.rs.