### PR TITLE
Revert "fix!: Split InputTakeAtPosition into complete/partial traits"

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -123,7 +123,7 @@ where
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsNot;
-    i.split_at_position1(|c| arr.find_token(c), e)
+    i.split_at_position1_complete(|c| arr.find_token(c), e)
   }
 }
 
@@ -157,7 +157,7 @@ where
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsA;
-    i.split_at_position1(|c| !arr.find_token(c), e)
+    i.split_at_position1_complete(|c| !arr.find_token(c), e)
   }
 }
 
@@ -187,7 +187,7 @@ where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position(|c| !cond(c))
+  move |i: Input| i.split_at_position_complete(|c| !cond(c))
 }
 
 /// Returns the longest (at least 1) input slice that matches the predicate.
@@ -219,7 +219,7 @@ where
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeWhile1;
-    i.split_at_position1(|c| !cond(c), e)
+    i.split_at_position1_complete(|c| !cond(c), e)
   }
 }
 
@@ -334,7 +334,7 @@ where
   Input: InputTakeAtPosition,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position(|c| cond(c))
+  move |i: Input| i.split_at_position_complete(|c| cond(c))
 }
 
 /// Returns the longest (at least 1) input slice till a predicate is met.
@@ -367,7 +367,7 @@ where
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeTill1;
-    i.split_at_position1(|c| cond(c), e)
+    i.split_at_position1_complete(|c| cond(c), e)
   }
 }
 

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -4,7 +4,7 @@ use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
   Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
-  InputTakeAtPositionStreaming, Slice, ToUsize,
+  InputTakeAtPosition, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::*;
@@ -118,8 +118,8 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  T: FindToken<<Input as InputTakeAtPositionStreaming>::Item>,
+  Input: InputTakeAtPosition,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsNot;
@@ -154,8 +154,8 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  T: FindToken<<Input as InputTakeAtPositionStreaming>::Item>,
+  Input: InputTakeAtPosition,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::IsA;
@@ -189,8 +189,8 @@ pub fn take_while<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
+  Input: InputTakeAtPosition,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position_streaming(|c| !cond(c))
 }
@@ -223,8 +223,8 @@ pub fn take_while1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
+  Input: InputTakeAtPosition,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeWhile1;
@@ -344,8 +344,8 @@ pub fn take_till<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
+  Input: InputTakeAtPosition,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| i.split_at_position_streaming(|c| cond(c))
 }
@@ -376,8 +376,8 @@ pub fn take_till1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTakeAtPositionStreaming,
-  F: Fn(<Input as InputTakeAtPositionStreaming>::Item) -> bool,
+  Input: InputTakeAtPosition,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     let e: ErrorKind = ErrorKind::TakeTill1;
@@ -532,7 +532,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPositionStreaming
+    + InputTakeAtPosition
     + Slice<RangeFrom<usize>>
     + InputIter,
   <Input as InputIter>::Item: crate::input::AsChar,
@@ -633,7 +633,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPositionStreaming
+    + InputTakeAtPosition
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -343,7 +343,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position(|item| !item.is_alpha())
+  input.split_at_position_complete(|item| !item.is_alpha())
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -368,7 +368,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position1(|item| !item.is_alpha(), ErrorKind::Alpha)
+  input.split_at_position1_complete(|item| !item.is_alpha(), ErrorKind::Alpha)
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
@@ -394,7 +394,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position(|item| !item.is_dec_digit())
+  input.split_at_position_complete(|item| !item.is_dec_digit())
 }
 
 /// Recognizes one or more ASCII numerical characters: 0-9
@@ -437,7 +437,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position1(|item| !item.is_dec_digit(), ErrorKind::Digit)
+  input.split_at_position1_complete(|item| !item.is_dec_digit(), ErrorKind::Digit)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -461,7 +461,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position(|item| !item.is_hex_digit())
+  input.split_at_position_complete(|item| !item.is_hex_digit())
 }
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
 ///
@@ -485,7 +485,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position1(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
+  input.split_at_position1_complete(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
 }
 
 /// Recognizes zero or more octal characters: 0-7
@@ -510,7 +510,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position(|item| !item.is_oct_digit())
+  input.split_at_position_complete(|item| !item.is_oct_digit())
 }
 
 /// Recognizes one or more octal characters: 0-7
@@ -535,7 +535,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position1(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
+  input.split_at_position1_complete(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -560,7 +560,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position(|item| !item.is_alphanum())
+  input.split_at_position_complete(|item| !item.is_alphanum())
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -585,7 +585,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar,
 {
-  input.split_at_position1(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
+  input.split_at_position1_complete(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -610,7 +610,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
-  input.split_at_position(|item| {
+  input.split_at_position_complete(|item| {
     let c = item.as_char();
     !(c == ' ' || c == '\t')
   })
@@ -638,7 +638,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
-  input.split_at_position1(
+  input.split_at_position1_complete(
     |item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t')
@@ -669,7 +669,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
-  input.split_at_position(|item| {
+  input.split_at_position_complete(|item| {
     let c = item.as_char();
     !(c == ' ' || c == '\t' || c == '\r' || c == '\n')
   })
@@ -697,7 +697,7 @@ where
   T: InputTakeAtPosition,
   <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
-  input.split_at_position1(
+  input.split_at_position1_complete(
     |item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t' || c == '\r' || c == '\n')

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -7,7 +7,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPositionStreaming, Slice,
+  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPosition, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -316,8 +316,8 @@ where
 /// ```
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position_streaming(|item| !item.is_alpha())
 }
@@ -337,8 +337,8 @@ where
 /// ```
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position1_streaming(|item| !item.is_alpha(), ErrorKind::Alpha)
 }
@@ -358,8 +358,8 @@ where
 /// ```
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position_streaming(|item| !item.is_dec_digit())
 }
@@ -379,8 +379,8 @@ where
 /// ```
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position1_streaming(|item| !item.is_dec_digit(), ErrorKind::Digit)
 }
@@ -400,8 +400,8 @@ where
 /// ```
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position_streaming(|item| !item.is_hex_digit())
 }
@@ -421,8 +421,8 @@ where
 /// ```
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position1_streaming(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
 }
@@ -442,8 +442,8 @@ where
 /// ```
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position_streaming(|item| !item.is_oct_digit())
 }
@@ -463,8 +463,8 @@ where
 /// ```
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position1_streaming(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
 }
@@ -484,8 +484,8 @@ where
 /// ```
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position_streaming(|item| !item.is_alphanum())
 }
@@ -505,8 +505,8 @@ where
 /// ```
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   input.split_at_position1_streaming(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
 }
@@ -526,8 +526,8 @@ where
 /// ```
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
   input.split_at_position_streaming(|item| {
     let c = item.as_char();
@@ -549,8 +549,8 @@ where
 /// ```
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
   input.split_at_position1_streaming(
     |item| {
@@ -576,8 +576,8 @@ where
 /// ```
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
   input.split_at_position_streaming(|item| {
     let c = item.as_char();
@@ -600,8 +600,8 @@ where
 /// ```
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar + Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
 {
   input.split_at_position1_streaming(
     |item| {

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -6,8 +6,7 @@ use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPositionStreaming,
-  Offset, Slice,
+  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPosition, Offset, Slice,
 };
 use crate::lib::std::ops::{RangeFrom, RangeTo};
 use crate::sequence::{pair, tuple};
@@ -1371,8 +1370,8 @@ where
   T: Clone + Offset,
   T: InputIter,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionStreaming + InputLength,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar
+  T: InputTakeAtPosition + InputLength,
+  <T as InputTakeAtPosition>::Item: AsChar
 {
   recognize(
     tuple((
@@ -1398,8 +1397,8 @@ where
   T: Clone + Offset,
   T: InputIter + InputTake + InputLength + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
 {
   alt((
     |i: T| {
@@ -1437,14 +1436,14 @@ where
   T: Clone + Offset,
   T: InputIter + crate::input::ParseTo<i32>,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPositionStreaming + InputTake + InputLength,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition + InputTake + InputLength,
+  <T as InputTakeAtPosition>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
 {
   let (i, sign) = sign(input.clone())?;
 
-  //let (i, zeroes) = take_while(|c: <T as InputTakeAtPositionStreaming>::Item| c.as_char() == '0')(i)?;
+  //let (i, zeroes) = take_while(|c: <T as InputTakeAtPosition>::Item| c.as_char() == '0')(i)?;
   let (i, zeroes) = match i.as_bytes().iter().position(|c| *c != b'0') {
     Some(index) => i.take_split(index),
     None => i.take_split(i.input_len()),
@@ -1547,8 +1546,8 @@ where
   T: InputIter + InputLength + InputTake + crate::input::ParseTo<f32> + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1601,8 +1600,8 @@ where
   T: InputIter + InputLength + InputTake + crate::input::ParseTo<f64> + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPositionStreaming,
-  <T as InputTakeAtPositionStreaming>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {


### PR DESCRIPTION
This reverts commit 6caa7b25372fa4a17a1ca599973014ea90d2b5df.

For now, #3 is looking like it causes more problems than its worth.  The Input into a complete/streaming specialized parser needs to be both, so splitting isn't offering any benefits.