### PR TITLE
feat: Auto-detect whether to use complete/streaming parser

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::iter::Iterator;
 
-use nom::bytes::complete::tag;
-use nom::character::complete::alphanumeric1;
+use nom::bytes::tag;
+use nom::character::alphanumeric1;
 use nom::combinator::iterator;
 use nom::sequence::{separated_pair, terminated};
 use nom::IResult;

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -2,12 +2,12 @@
 
 use nom::{
   branch::alt,
-  bytes::complete::{escaped, tag, take_while},
-  character::complete::{alphanumeric1 as alphanumeric, char, one_of},
+  bytes::{escaped, tag, take_while},
+  character::{alphanumeric1 as alphanumeric, char, one_of},
   combinator::{cut, map, opt, value},
   error::{context, convert_error, ContextError, ErrorKind, ParseError, VerboseError},
   multi::separated_list0,
-  number::complete::double,
+  number::double,
   sequence::{delimited, preceded, separated_pair, terminated},
   Err, IResult,
 };

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -2,20 +2,20 @@
 
 use nom::{
   branch::alt,
-  bytes::complete::{escaped, tag, take_while},
-  character::complete::{alphanumeric1 as alphanumeric, char, one_of},
-  combinator::{map, opt, cut},
+  bytes::{escaped, tag, take_while},
+  character::{alphanumeric1 as alphanumeric, char, one_of},
+  combinator::{cut, map, opt},
   error::{context, ErrorKind, ParseError},
   error::{VerboseError, VerboseErrorKind},
   multi::separated_list,
-  number::complete::double,
+  number::double,
   sequence::{delimited, preceded, separated_pair, terminated},
   Err, IResult, Offset,
 };
 use std::collections::HashMap;
 
-use std::str;
 use std::cell::Cell;
+use std::str;
 
 struct Cursor<'a> {
   inner: &'a str,
@@ -28,7 +28,7 @@ pub struct JsonValue<'a, 'b> {
   pub offset: &'b Cell<usize>,
 }
 
-impl<'a, 'b:'a> JsonValue<'a, 'b> {
+impl<'a, 'b: 'a> JsonValue<'a, 'b> {
   pub fn new(input: &'a str, offset: &'b Cell<usize>) -> JsonValue<'a, 'b> {
     JsonValue { input, offset }
   }
@@ -49,7 +49,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
         self.offset(i);
         println!("-> {}", s);
         Some(s)
-      },
+      }
       _ => None,
     }
   }
@@ -61,27 +61,27 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
         self.offset(i);
         println!("-> {}", o);
         Some(o)
-      },
+      }
       _ => None,
     }
   }
 
   pub fn number(&self) -> Option<f64> {
     println!("number()");
-    match double::<_,()>(self.data()) {
+    match double::<_, ()>(self.data()) {
       Ok((i, o)) => {
         self.offset(i);
         println!("-> {}", o);
         Some(o)
-      },
+      }
       _ => None,
     }
   }
 
-  pub fn array(&self) -> Option<impl Iterator<Item=JsonValue<'a, 'b>>> {
+  pub fn array(&self) -> Option<impl Iterator<Item = JsonValue<'a, 'b>>> {
     println!("array()");
 
-    match tag::<_,_,()>("[")(self.data()) {
+    match tag::<_, _, ()>("[")(self.data()) {
       Err(_) => None,
       Ok((i, _)) => {
         println!("[");
@@ -92,7 +92,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
 
         let v = self.clone();
 
-        Some(std::iter::from_fn(move|| {
+        Some(std::iter::from_fn(move || {
           if done {
             return None;
           }
@@ -103,30 +103,29 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             match value(v.data()) {
               Ok((i, _)) => {
                 v.offset(i);
-              },
-              Err(_) => {},
+              }
+              Err(_) => {}
             }
           }
 
-
-          match tag::<_,_,()>("]")(v.data()) {
+          match tag::<_, _, ()>("]")(v.data()) {
             Ok((i, _)) => {
               println!("]");
               v.offset(i);
               done = true;
               return None;
-            },
+            }
             Err(_) => {}
           };
 
           if first {
             first = false;
           } else {
-            match tag::<_,_,()>(",")(v.data()) {
+            match tag::<_, _, ()>(",")(v.data()) {
               Ok((i, _)) => {
-               println!(",");
+                println!(",");
                 v.offset(i);
-              },
+              }
               Err(_) => {
                 done = true;
                 return None;
@@ -137,15 +136,14 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
           println!("-> {}", v.data());
           previous = v.offset.get();
           Some(v.clone())
-
         }))
       }
     }
   }
 
-  pub fn object(&self) -> Option<impl Iterator<Item=(&'a str, JsonValue<'a, 'b>)>> {
+  pub fn object(&self) -> Option<impl Iterator<Item = (&'a str, JsonValue<'a, 'b>)>> {
     println!("object()");
-    match tag::<_,_,()>("{")(self.data()) {
+    match tag::<_, _, ()>("{")(self.data()) {
       Err(_) => None,
       Ok((i, _)) => {
         self.offset(i);
@@ -158,7 +156,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
 
         let v = self.clone();
 
-        Some(std::iter::from_fn(move|| {
+        Some(std::iter::from_fn(move || {
           if done {
             return None;
           }
@@ -169,29 +167,29 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             match value(v.data()) {
               Ok((i, _)) => {
                 v.offset(i);
-              },
-              Err(_) => {},
+              }
+              Err(_) => {}
             }
           }
 
-          match tag::<_,_,()>("}")(v.data()) {
+          match tag::<_, _, ()>("}")(v.data()) {
             Ok((i, _)) => {
               println!("}}");
               v.offset(i);
               done = true;
               return None;
-            },
+            }
             Err(_) => {}
           };
 
           if first {
             first = false;
           } else {
-            match tag::<_,_,()>(",")(v.data()) {
+            match tag::<_, _, ()>(",")(v.data()) {
               Ok((i, _)) => {
                 println!(",");
                 v.offset(i);
-              },
+              }
               Err(_) => {
                 done = true;
                 return None;
@@ -203,7 +201,7 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
             Ok((i, key)) => {
               v.offset(i);
 
-              match tag::<_,_,()>(":")(v.data()) {
+              match tag::<_, _, ()>(":")(v.data()) {
                 Err(_) => None,
                 Ok((i, _)) => {
                   v.offset(i);
@@ -214,10 +212,9 @@ impl<'a, 'b:'a> JsonValue<'a, 'b> {
                   Some((key, v.clone()))
                 }
               }
-            },
+            }
             _ => None,
           }
-
         }))
       }
     }
@@ -235,47 +232,44 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 }
 
 fn string<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
-  context("string",
-    preceded(
-      char('\"'),
-      cut(terminated(
-          parse_str,
-          char('\"')
-  ))))(i)
+  context(
+    "string",
+    preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
+  )(i)
 }
 
 fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
-  alt((
-      map(tag("false"), |_| false),
-      map(tag("true"), |_| true)
-  ))(input)
+  alt((map(tag("false"), |_| false), map(tag("true"), |_| true)))(input)
 }
 
 fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
   context(
     "array",
-    preceded(char('['),
-    cut(terminated(
-      map(separated_list(preceded(sp, char(',')), value), |_| ()),
-      preceded(sp, char(']'))))
-  ))(i)
+    preceded(
+      char('['),
+      cut(terminated(
+        map(separated_list(preceded(sp, char(',')), value), |_| ()),
+        preceded(sp, char(']')),
+      )),
+    ),
+  )(i)
 }
 
 fn key_value<'a>(i: &'a str) -> IResult<&'a str, (&'a str, ())> {
-separated_pair(preceded(sp, string), cut(preceded(sp, char(':'))), value)(i)
+  separated_pair(preceded(sp, string), cut(preceded(sp, char(':'))), value)(i)
 }
 
 fn hash<'a>(i: &'a str) -> IResult<&'a str, ()> {
   context(
     "map",
-    preceded(char('{'),
-    cut(terminated(
-      map(
-        separated_list(preceded(sp, char(',')), key_value),
-        |_| ()),
-      preceded(sp, char('}')),
-    ))
-  ))(i)
+    preceded(
+      char('{'),
+      cut(terminated(
+        map(separated_list(preceded(sp, char(',')), key_value), |_| ()),
+        preceded(sp, char('}')),
+      )),
+    ),
+  )(i)
 }
 
 fn value<'a>(i: &'a str) -> IResult<&'a str, ()> {
@@ -314,13 +308,17 @@ fn main() {
     let parser = JsonValue::new(data, &offset);
 
     if let Some(o) = parser.object() {
-      let s: HashMap<&str, &str> = o.filter(|(k,_)| *k == "users" )
-         .filter_map(|(_, v)| v.object()).flatten()
-         .filter_map(|(user, v)| v.object().map(|o| (user, o)))
-         .map(|(user, o)| {
-            o.filter(|(k,_)| *k == "city" )
-             .filter_map(move |(_, v)| v.string().map(|s| (user, s)))
-          }).flatten().collect();
+      let s: HashMap<&str, &str> = o
+        .filter(|(k, _)| *k == "users")
+        .filter_map(|(_, v)| v.object())
+        .flatten()
+        .filter_map(|(user, v)| v.object().map(|o| (user, o)))
+        .map(|(user, o)| {
+          o.filter(|(k, _)| *k == "city")
+            .filter_map(move |(_, v)| v.string().map(|s| (user, s)))
+        })
+        .flatten()
+        .collect();
 
       println!("res = {:?}", s);
     }

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -6,8 +6,8 @@
 
 use nom::{
   branch::alt,
-  bytes::complete::tag,
-  character::complete::{alpha1, char, digit1, multispace0, multispace1, one_of},
+  bytes::tag,
+  character::{alpha1, char, digit1, multispace0, multispace1, one_of},
   combinator::{cut, map, map_res, opt},
   error::{context, VerboseError},
   multi::many0,

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -12,8 +12,8 @@
 #![cfg(feature = "alloc")]
 
 use nom::branch::alt;
-use nom::bytes::streaming::{is_not, take_while_m_n};
-use nom::character::streaming::{char, multispace1};
+use nom::bytes::{is_not, take_while_m_n};
+use nom::character::{char, multispace1};
 use nom::combinator::{map, map_opt, map_res, value, verify};
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -1,6 +1,8 @@
 //! Bit level parsers
 //!
 
+#![allow(deprecated)]
+
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{InputIter, InputLength, Slice, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, RangeFrom, Shl, Shr};
@@ -30,6 +32,9 @@ use crate::{Err, IResult};
 /// // Tries to consume 12 bits but only 8 are available
 /// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(nom::Err::Error(Error{input: ([0b00010010].as_ref(), 0), code: ErrorKind::Eof })));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bits::take`][crate::bits::take]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bits::take`")]
 pub fn take<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
@@ -91,6 +96,9 @@ where
 }
 
 /// Generates a parser taking `count` bits and comparing them to `pattern`
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bits::tag`][crate::bits::tag]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bits::tag`")]
 pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
   pattern: O,
   count: C,

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -39,44 +39,53 @@ where
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
   let count = count.to_usize();
-  move |(input, bit_offset): (I, usize)| {
-    if count == 0 {
-      Ok(((input, bit_offset), 0u8.into()))
+  move |input: (I, usize)| take_internal(input, count)
+}
+
+pub(crate) fn take_internal<I, O, E: ParseError<(I, usize)>>(
+  (input, bit_offset): (I, usize),
+  count: usize,
+) -> IResult<(I, usize), O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
+{
+  if count == 0 {
+    Ok(((input, bit_offset), 0u8.into()))
+  } else {
+    let cnt = (count + bit_offset).div(8);
+    if input.input_len() * 8 < count + bit_offset {
+      Err(Err::Error(E::from_error_kind(
+        (input, bit_offset),
+        ErrorKind::Eof,
+      )))
     } else {
-      let cnt = (count + bit_offset).div(8);
-      if input.input_len() * 8 < count + bit_offset {
-        Err(Err::Error(E::from_error_kind(
-          (input, bit_offset),
-          ErrorKind::Eof,
-        )))
-      } else {
-        let mut acc: O = 0_u8.into();
-        let mut offset: usize = bit_offset;
-        let mut remaining: usize = count;
-        let mut end_offset: usize = 0;
+      let mut acc: O = 0_u8.into();
+      let mut offset: usize = bit_offset;
+      let mut remaining: usize = count;
+      let mut end_offset: usize = 0;
 
-        for byte in input.iter_elements().take(cnt + 1) {
-          if remaining == 0 {
-            break;
-          }
-          let val: O = if offset == 0 {
-            byte.into()
-          } else {
-            ((byte << offset) as u8 >> offset).into()
-          };
-
-          if remaining < 8 - offset {
-            acc += val >> (8 - offset - remaining);
-            end_offset = remaining + offset;
-            break;
-          } else {
-            acc += val << (remaining - (8 - offset));
-            remaining -= 8 - offset;
-            offset = 0;
-          }
+      for byte in input.iter_elements().take(cnt + 1) {
+        if remaining == 0 {
+          break;
         }
-        Ok(((input.slice(cnt..), end_offset), acc))
+        let val: O = if offset == 0 {
+          byte.into()
+        } else {
+          ((byte << offset) as u8 >> offset).into()
+        };
+
+        if remaining < 8 - offset {
+          acc += val >> (8 - offset - remaining);
+          end_offset = remaining + offset;
+          break;
+        } else {
+          acc += val << (remaining - (8 - offset));
+          remaining -= 8 - offset;
+          offset = 0;
+        }
       }
+      Ok(((input.slice(cnt..), end_offset), acc))
     }
   }
 }
@@ -92,17 +101,27 @@ where
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
   let count = count.to_usize();
-  move |input: (I, usize)| {
-    let inp = input.clone();
+  move |input: (I, usize)| tag_internal(input, &pattern, count)
+}
 
-    take(count)(input).and_then(|(i, o)| {
-      if pattern == o {
-        Ok((i, o))
-      } else {
-        Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
-      }
-    })
-  }
+pub(crate) fn tag_internal<I, O, E: ParseError<(I, usize)>>(
+  input: (I, usize),
+  pattern: &O,
+  count: usize,
+) -> IResult<(I, usize), O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+{
+  let inp = input.clone();
+
+  take_internal(input, count).and_then(|(i, o)| {
+    if *pattern == o {
+      Ok((i, o))
+    } else {
+      Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
+    }
+  })
 }
 
 #[cfg(test)]

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -18,7 +18,7 @@ use crate::{Err, IResult, Needed, Parser};
 ///
 /// # Example
 /// ```
-/// use nom::bits::{bits, streaming::take};
+/// use nom::bits::{bits, take};
 /// use nom::error::Error;
 /// use nom::sequence::tuple;
 /// use nom::IResult;
@@ -67,7 +67,7 @@ where
 /// at the next full byte.
 ///
 /// ```
-/// use nom::bits::{bits, bytes, streaming::take};
+/// use nom::bits::{bits, bytes, take};
 /// use nom::combinator::rest;
 /// use nom::error::Error;
 /// use nom::sequence::tuple;
@@ -116,7 +116,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use nom::bits::complete::take;
+/// # use nom::bits::take;
 /// # use nom::IResult;
 /// # use nom::error::{Error, ErrorKind};
 /// // Input is a tuple of (input: I, bit_offset: usize)

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -1,12 +1,20 @@
 //! Bit level parsers
 //!
 
+#![allow(deprecated)]
+
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{InputIter, InputLength, Slice, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, RangeFrom, Shl, Shr};
 use crate::{Err, IResult, Needed};
 
 /// Generates a parser taking `count` bits
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bits::take`][crate::bits::take] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bits::take` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
@@ -65,6 +73,12 @@ where
 }
 
 /// Generates a parser taking `count` bits and comparing them to `pattern`
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bits::tag`][crate::bits::tag] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bits::tag` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
   pattern: O,
   count: C,

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -16,41 +16,50 @@ where
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
   let count = count.to_usize();
-  move |(input, bit_offset): (I, usize)| {
-    if count == 0 {
-      Ok(((input, bit_offset), 0u8.into()))
+  move |input: (I, usize)| take_internal(input, count)
+}
+
+pub(crate) fn take_internal<I, O, E: ParseError<(I, usize)>>(
+  (input, bit_offset): (I, usize),
+  count: usize,
+) -> IResult<(I, usize), O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
+{
+  if count == 0 {
+    Ok(((input, bit_offset), 0u8.into()))
+  } else {
+    let cnt = (count + bit_offset).div(8);
+    if input.input_len() * 8 < count + bit_offset {
+      Err(Err::Incomplete(Needed::new(count as usize)))
     } else {
-      let cnt = (count + bit_offset).div(8);
-      if input.input_len() * 8 < count + bit_offset {
-        Err(Err::Incomplete(Needed::new(count as usize)))
-      } else {
-        let mut acc: O = 0_u8.into();
-        let mut offset: usize = bit_offset;
-        let mut remaining: usize = count;
-        let mut end_offset: usize = 0;
+      let mut acc: O = 0_u8.into();
+      let mut offset: usize = bit_offset;
+      let mut remaining: usize = count;
+      let mut end_offset: usize = 0;
 
-        for byte in input.iter_elements().take(cnt + 1) {
-          if remaining == 0 {
-            break;
-          }
-          let val: O = if offset == 0 {
-            byte.into()
-          } else {
-            ((byte << offset) as u8 >> offset).into()
-          };
-
-          if remaining < 8 - offset {
-            acc += val >> (8 - offset - remaining);
-            end_offset = remaining + offset;
-            break;
-          } else {
-            acc += val << (remaining - (8 - offset));
-            remaining -= 8 - offset;
-            offset = 0;
-          }
+      for byte in input.iter_elements().take(cnt + 1) {
+        if remaining == 0 {
+          break;
         }
-        Ok(((input.slice(cnt..), end_offset), acc))
+        let val: O = if offset == 0 {
+          byte.into()
+        } else {
+          ((byte << offset) as u8 >> offset).into()
+        };
+
+        if remaining < 8 - offset {
+          acc += val >> (8 - offset - remaining);
+          end_offset = remaining + offset;
+          break;
+        } else {
+          acc += val << (remaining - (8 - offset));
+          remaining -= 8 - offset;
+          offset = 0;
+        }
       }
+      Ok(((input.slice(cnt..), end_offset), acc))
     }
   }
 }
@@ -66,17 +75,27 @@ where
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
   let count = count.to_usize();
-  move |input: (I, usize)| {
-    let inp = input.clone();
+  move |input: (I, usize)| tag_internal(input, &pattern, count)
+}
 
-    take(count)(input).and_then(|(i, o)| {
-      if pattern == o {
-        Ok((i, o))
-      } else {
-        Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
-      }
-    })
-  }
+pub(crate) fn tag_internal<I, O, E: ParseError<(I, usize)>>(
+  input: (I, usize),
+  pattern: &O,
+  count: usize,
+) -> IResult<(I, usize), O, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+{
+  let inp = input.clone();
+
+  take(count)(input).and_then(|(i, o)| {
+    if *pattern == o {
+      Ok((i, o))
+    } else {
+      Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
+    }
+  })
 }
 
 #[cfg(test)]

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -1,14 +1,13 @@
 use super::*;
 use crate::error::Error;
+use crate::input::Streaming;
 use crate::sequence::tuple;
 
 #[test]
 /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
 /// previous bytes are fully consumed
 fn test_complete_byte_consumption_bits() {
-  use crate::bits::streaming::take;
-
-  let input = &[0x12, 0x34, 0x56, 0x78];
+  let input = &[0x12, 0x34, 0x56, 0x78][..];
 
   // Take 3 bit slices with sizes [4, 8, 4].
   let result: IResult<&[u8], (u8, u8, u8)> =
@@ -33,9 +32,7 @@ fn test_complete_byte_consumption_bits() {
 /// I.e. if we consume 1.5 bytes of 4 bytes, 2 bytes will be returned, bits 13-16 will be
 /// dropped.
 fn test_partial_byte_consumption_bits() {
-  use crate::bits::streaming::take;
-
-  let input = &[0x12, 0x34, 0x56, 0x78];
+  let input = &[0x12, 0x34, 0x56, 0x78][..];
 
   // Take bit slices with sizes [4, 8].
   let result: IResult<&[u8], (u8, u8)> =
@@ -55,14 +52,94 @@ fn test_partial_byte_consumption_bits() {
 #[cfg(feature = "std")]
 /// Ensure that in Incomplete error is thrown, if too few bytes are passed for a given parser.
 fn test_incomplete_bits() {
-  use crate::bits::streaming::take;
-  let input = &[0x12];
+  let input = Streaming(&[0x12][..]);
 
   // Take bit slices with sizes [4, 8].
-  let result: IResult<&[u8], (u8, u8)> =
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+  let result: IResult<_, (u8, u8)> =
+    bits::<_, _, Error<(_, usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
 
   assert!(result.is_err());
   let error = result.err().unwrap();
   assert_eq!("Parsing requires 2 bytes/chars", error.to_string());
+}
+
+#[test]
+fn test_take_complete_0() {
+  let input = &[0b00010010][..];
+  let count = 0usize;
+  assert_eq!(count, 0usize);
+  let offset = 0usize;
+
+  let result: crate::IResult<(&[u8], usize), usize> = take(count)((input, offset));
+
+  assert_eq!(result, Ok(((input, offset), 0)));
+}
+
+#[test]
+fn test_take_complete_eof() {
+  let input = &[0b00010010][..];
+
+  let result: crate::IResult<(&[u8], usize), usize> = take(1usize)((input, 8));
+
+  assert_eq!(
+    result,
+    Err(crate::Err::Error(crate::error::Error {
+      input: (input, 8),
+      code: ErrorKind::Eof
+    }))
+  )
+}
+
+#[test]
+fn test_take_complete_span_over_multiple_bytes() {
+  let input = &[0b00010010, 0b00110100, 0b11111111, 0b11111111][..];
+
+  let result: crate::IResult<(&[u8], usize), usize> = take(24usize)((input, 4));
+
+  assert_eq!(
+    result,
+    Ok((([0b11111111].as_ref(), 4), 0b1000110100111111111111))
+  );
+}
+
+#[test]
+fn test_take_streaming_0() {
+  let input = Streaming(&[][..]);
+  let count = 0usize;
+  assert_eq!(count, 0usize);
+  let offset = 0usize;
+
+  let result: crate::IResult<(_, usize), usize> = take(count)((input, offset));
+
+  assert_eq!(result, Ok(((input, offset), 0)));
+}
+
+#[test]
+fn test_tag_streaming_ok() {
+  let input = Streaming(&[0b00011111][..]);
+  let offset = 0usize;
+  let bits_to_take = 4usize;
+  let value_to_tag = 0b0001;
+
+  let result: crate::IResult<(_, usize), usize> = tag(value_to_tag, bits_to_take)((input, offset));
+
+  assert_eq!(result, Ok(((input, bits_to_take), value_to_tag)));
+}
+
+#[test]
+fn test_tag_streaming_err() {
+  let input = Streaming(&[0b00011111][..]);
+  let offset = 0usize;
+  let bits_to_take = 4usize;
+  let value_to_tag = 0b1111;
+
+  let result: crate::IResult<(_, usize), usize> = tag(value_to_tag, bits_to_take)((input, offset));
+
+  assert_eq!(
+    result,
+    Err(crate::Err::Error(crate::error::Error {
+      input: (input, offset),
+      code: ErrorKind::TagBits
+    }))
+  );
 }

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -24,7 +24,7 @@ pub trait Alt<I, O, E> {
 /// ```rust
 /// # use nom::error_position;
 /// # use nom::{Err,error::ErrorKind, Needed, IResult};
-/// use nom::character::complete::{alpha1, digit1};
+/// use nom::character::{alpha1, digit1};
 /// use nom::branch::alt;
 /// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, &str> {
@@ -66,7 +66,7 @@ pub trait Permutation<I, O, E> {
 ///
 /// ```rust
 /// # use nom::{Err,error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::character::complete::{alpha1, digit1};
+/// use nom::character::{alpha1, digit1};
 /// use nom::branch::permutation;
 /// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, (&str, &str)> {
@@ -89,7 +89,7 @@ pub trait Permutation<I, O, E> {
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, IResult};
 /// use nom::branch::permutation;
-/// use nom::character::complete::{anychar, char};
+/// use nom::character::{anychar, char};
 ///
 /// fn parser(input: &str) -> IResult<&str, (char, char)> {
 ///   permutation((anychar, char('a')))(input)

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -1,5 +1,7 @@
 //! Parsers recognizing bytes streams, complete input version
 
+#![allow(deprecated)]
+
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
@@ -30,6 +32,9 @@ use crate::{Err, IResult, Parser};
 /// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::tag`][crate::bytes::tag]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::tag`")]
 pub fn tag<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -82,6 +87,9 @@ where
 /// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::tag_no_case`][crate::bytes::tag_no_case]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::tag_no_case`")]
 pub fn tag_no_case<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -135,6 +143,9 @@ where
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
 /// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_not`][crate::bytes::is_not]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::is_not`")]
 pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -181,6 +192,9 @@ where
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
 /// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_a`][crate::bytes::is_a]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::is_a`")]
 pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -225,6 +239,9 @@ where
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while`][crate::bytes::take_while]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while`")]
 pub fn take_while<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -268,6 +285,9 @@ where
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while1`][crate::bytes::take_while1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while1`")]
 pub fn take_while1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -315,6 +335,9 @@ where
 /// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
 /// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while_m_n`][crate::bytes::take_while_m_n]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while_m_n`")]
 pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(
   m: usize,
   n: usize,
@@ -407,6 +430,9 @@ where
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
 /// assert_eq!(till_colon(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till`][crate::bytes::take_till]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_till`")]
 pub fn take_till<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -451,6 +477,9 @@ where
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
 /// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till1`][crate::bytes::take_till1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_till1`")]
 pub fn take_till1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -504,6 +533,9 @@ where
 /// assert_eq!(take::<_, _, Error<_>>(1usize)("💙"), Ok(("", "💙")));
 /// assert_eq!(take::<_, _, Error<_>>(1usize)("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take`][crate::bytes::take]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take`")]
 pub fn take<C, Input, Error: ParseError<Input>>(
   count: C,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -548,6 +580,9 @@ where
 /// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_until`][crate::bytes::take_until]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_until`")]
 pub fn take_until<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -594,6 +629,9 @@ where
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_until1`][crate::bytes::take_until1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_until1`")]
 pub fn take_until1<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -642,6 +680,9 @@ where
 /// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
 /// ```
 ///
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::escaped`][crate::bytes::escaped]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::escaped`")]
 pub fn escaped<'a, Input: 'a, Error, F, G, O1, O2>(
   mut normal: F,
   control_char: char,
@@ -777,6 +818,12 @@ where
 /// assert_eq!(parser("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
 /// ```
 #[cfg(feature = "alloc")]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::escaped_transform`][crate::bytes::escaped_transform]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::escaped_transform`"
+)]
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
   mut normal: F,
   control_char: char,

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -726,9 +726,9 @@ where
 /// # Example
 /// ```
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use nom::character::complete::digit1;
+/// # use nom::character::digit1;
 /// use nom::bytes::escaped;
-/// use nom::character::complete::one_of;
+/// use nom::character::one_of;
 ///
 /// fn esc(s: &str) -> IResult<&str, &str> {
 ///   escaped(digit1, '\\', one_of(r#""n\"#))(s)
@@ -740,10 +740,10 @@ where
 ///
 /// ```
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use nom::character::streaming::digit1;
+/// # use nom::character::digit1;
 /// # use nom::input::Streaming;
 /// use nom::bytes::escaped;
-/// use nom::character::streaming::one_of;
+/// use nom::character::one_of;
 ///
 /// fn esc(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
 ///   escaped(digit1, '\\', one_of("\"n\\"))(s)
@@ -794,7 +794,7 @@ where
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// # use std::str::from_utf8;
 /// use nom::bytes::{escaped_transform, tag};
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// use nom::branch::alt;
 /// use nom::combinator::value;
 ///
@@ -819,7 +819,7 @@ where
 /// # use std::str::from_utf8;
 /// # use nom::input::Streaming;
 /// use nom::bytes::{escaped_transform, tag};
-/// use nom::character::streaming::alpha1;
+/// use nom::character::alpha1;
 /// use nom::branch::alt;
 /// use nom::combinator::value;
 ///

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -2,3 +2,871 @@
 
 pub mod complete;
 pub mod streaming;
+#[cfg(test)]
+mod tests;
+
+use crate::error::ParseError;
+use crate::input::{
+  Compare, FindSubstring, FindToken, InputIsStreaming, InputIter, InputLength, InputTake,
+  InputTakeAtPosition, IntoOutput, Slice, ToUsize,
+};
+use crate::lib::std::ops::RangeFrom;
+use crate::{IResult, Parser};
+
+/// Recognizes a pattern
+///
+/// The input data will be compared to the tag combinator's argument and will return the part of
+/// the input that matches the argument
+///
+/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag("Hello")(s)
+/// }
+///
+/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::tag;
+///
+/// fn parser(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   tag("Hello")(s)
+/// }
+///
+/// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
+/// assert_eq!(parser(Streaming("Something")), Err(Err::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("S")), Err(Err::Error(Error::new(Streaming("S"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("H")), Err(Err::Incomplete(Needed::new(4))));
+/// ```
+#[inline(always)]
+pub fn tag<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  tag: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + Compare<T> + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: InputLength + Clone,
+{
+  move |i: Input| {
+    let t = tag.clone();
+    if STREAMING {
+      streaming::tag_internal(i, t)
+    } else {
+      complete::tag_internal(i, t)
+    }
+  }
+}
+
+/// Recognizes a case insensitive pattern.
+///
+/// The input data will be compared to the tag combinator's argument and will return the part of
+/// the input that matches the argument with no regard to case.
+///
+/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::tag_no_case;
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   tag_no_case("hello")(s)
+/// }
+///
+/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
+/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
+/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::tag_no_case;
+///
+/// fn parser(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   tag_no_case("hello")(s)
+/// }
+///
+/// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
+/// assert_eq!(parser(Streaming("hello, World!")), Ok((Streaming(", World!"), "hello")));
+/// assert_eq!(parser(Streaming("HeLlO, World!")), Ok((Streaming(", World!"), "HeLlO")));
+/// assert_eq!(parser(Streaming("Something")), Err(Err::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::new(5))));
+/// ```
+#[inline(always)]
+pub fn tag_no_case<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  tag: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + Compare<T> + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: InputLength + Clone,
+{
+  move |i: Input| {
+    let t = tag.clone();
+    if STREAMING {
+      streaming::tag_no_case_internal(i, t)
+    } else {
+      complete::tag_no_case_internal(i, t)
+    }
+  }
+}
+
+/// Parse till certain characters are met.
+///
+/// The parser will return the longest slice till one of the characters of the combinator's argument are met.
+///
+/// It doesn't consume the matched character.
+///
+/// *Complete version*: It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
+///
+/// *Streaming version*: It will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::is_not;
+///
+/// fn not_space(s: &str) -> IResult<&str, &str> {
+///   is_not(" \t\r\n")(s)
+/// }
+///
+/// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
+/// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
+/// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
+/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::is_not;
+///
+/// fn not_space(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   is_not(" \t\r\n")(s)
+/// }
+///
+/// assert_eq!(not_space(Streaming("Hello, World!")), Ok((Streaming(" World!"), "Hello,")));
+/// assert_eq!(not_space(Streaming("Sometimes\t")), Ok((Streaming("\t"), "Sometimes")));
+/// assert_eq!(not_space(Streaming("Nospace")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn is_not<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  arr: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  Input: InputTakeAtPosition,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::is_not_internal(i, &arr)
+    } else {
+      complete::is_not_internal(i, &arr)
+    }
+  }
+}
+
+/// Returns the longest slice of the matches the pattern.
+///
+/// The parser will return the longest slice consisting of the characters in provided in the
+/// combinator's argument.
+///
+/// *Complete version*: It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
+///
+/// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met
+/// or if the pattern reaches the end of the input.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::is_a;
+///
+/// fn hex(s: &str) -> IResult<&str, &str> {
+///   is_a("1234567890ABCDEF")(s)
+/// }
+///
+/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
+/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
+/// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
+/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::is_a;
+///
+/// fn hex(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   is_a("1234567890ABCDEF")(s)
+/// }
+///
+/// assert_eq!(hex(Streaming("123 and voila")), Ok((Streaming(" and voila"), "123")));
+/// assert_eq!(hex(Streaming("DEADBEEF and others")), Ok((Streaming(" and others"), "DEADBEEF")));
+/// assert_eq!(hex(Streaming("BADBABEsomething")), Ok((Streaming("something"), "BADBABE")));
+/// assert_eq!(hex(Streaming("D15EA5E")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn is_a<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  arr: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  Input: InputTakeAtPosition,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::is_a_internal(i, &arr)
+    } else {
+      complete::is_a_internal(i, &arr)
+    }
+  }
+}
+
+/// Returns the longest input slice (if any) that matches the predicate.
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*.
+///
+/// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::bytes::take_while;
+/// use nom::input::AsChar;
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while(AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
+/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_while;
+/// use nom::input::AsChar;
+///
+/// fn alpha(s: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+///   take_while(AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha(Streaming(b"12345")), Ok((Streaming(&b"12345"[..]), &b""[..])));
+/// assert_eq!(alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Streaming(b"")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn take_while<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  cond: F,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  Input: InputTakeAtPosition,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_while_internal(i, &cond)
+    } else {
+      complete::take_while_internal(i, &cond)
+    }
+  }
+}
+
+/// Returns the longest (at least 1) input slice that matches the predicate.
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*.
+///
+/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+///
+/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take_while1;
+/// use nom::input::AsChar;
+///
+/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while1(AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_while1;
+/// use nom::input::AsChar;
+///
+/// fn alpha(s: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+///   take_while1(AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
+/// ```
+#[inline(always)]
+pub fn take_while1<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  cond: F,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_while1_internal(i, &cond)
+    } else {
+      complete::take_while1_internal(i, &cond)
+    }
+  }
+}
+
+/// Returns the longest (m <= len <= n) input slice  that matches the predicate.
+///
+/// The parser will return the longest slice that matches the given predicate *(a function that
+/// takes the input and returns a bool)*.
+///
+/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// of range (m <= len <= n).
+///
+/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take_while_m_n;
+/// use nom::input::AsChar;
+///
+/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while_m_n(3, 6, AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_while_m_n;
+/// use nom::input::AsChar;
+///
+/// fn short_alpha(s: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+///   take_while_m_n(3, 6, AsChar::is_alpha)(s)
+/// }
+///
+/// assert_eq!(short_alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(short_alpha(Streaming(b"lengthy")), Ok((Streaming(&b"y"[..]), &b"length"[..])));
+/// assert_eq!(short_alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Streaming(b"ed")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
+/// ```
+#[inline(always)]
+pub fn take_while_m_n<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  m: usize,
+  n: usize,
+  cond: F,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input:
+    InputTake + InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  F: Fn(<Input as InputIter>::Item) -> bool,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_while_m_n_internal(i, m, n, &cond)
+    } else {
+      complete::take_while_m_n_internal(i, m, n, &cond)
+    }
+  }
+}
+
+/// Returns the longest input slice (if any) till a predicate is met.
+///
+/// The parser will return the longest slice till the given predicate *(a function that
+/// takes the input and returns a bool)*.
+///
+/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// end of input or if there was not match.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::bytes::take_till;
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till(|c| c == ':')(s)
+/// }
+///
+/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
+/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
+/// assert_eq!(till_colon(""), Ok(("", "")));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_till;
+///
+/// fn till_colon(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   take_till(|c| c == ':')(s)
+/// }
+///
+/// assert_eq!(till_colon(Streaming("latin:123")), Ok((Streaming(":123"), "latin")));
+/// assert_eq!(till_colon(Streaming(":empty matched")), Ok((Streaming(":empty matched"), ""))); //allowed
+/// assert_eq!(till_colon(Streaming("12345")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn take_till<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  cond: F,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_till_internal(i, &cond)
+    } else {
+      complete::take_till_internal(i, &cond)
+    }
+  }
+}
+
+/// Returns the longest (at least 1) input slice till a predicate is met.
+///
+/// The parser will return the longest slice till the given predicate *(a function that
+/// takes the input and returns a bool)*.
+///
+/// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// predicate matches the first input.
+///
+/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// end of input or if there was not match.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take_till1;
+///
+/// fn till_colon(s: &str) -> IResult<&str, &str> {
+///   take_till1(|c| c == ':')(s)
+/// }
+///
+/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
+/// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_till1;
+///
+/// fn till_colon(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   take_till1(|c| c == ':')(s)
+/// }
+///
+/// assert_eq!(till_colon(Streaming("latin:123")), Ok((Streaming(":123"), "latin")));
+/// assert_eq!(till_colon(Streaming(":empty matched")), Err(Err::Error(Error::new(Streaming(":empty matched"), ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(Streaming("12345")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn take_till1<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  cond: F,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_till1_internal(i, &cond)
+    } else {
+      complete::take_till1_internal(i, &cond)
+    }
+  }
+}
+
+/// Returns an input slice containing the first N input elements (Input[..N]).
+///
+/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
+///
+/// *Streaming version*: if the input has less than N elements, `take` will
+/// return a `Err::Incomplete(Needed::new(M))` where M is the number of
+/// additional bytes the parser would need to succeed.
+/// It is well defined for `&[u8]` as the number of elements is the byte size,
+/// but for types like `&str`, we cannot know how many bytes correspond for
+/// the next few chars, so the result will be `Err::Incomplete(Needed::Unknown)`
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take;
+///
+/// fn take6(s: &str) -> IResult<&str, &str> {
+///   take(6usize)(s)
+/// }
+///
+/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
+/// assert_eq!(take6("things"), Ok(("", "things")));
+/// assert_eq!(take6("short"), Err(Err::Error(Error::new("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```
+///
+/// The units that are taken will depend on the input type. For example, for a
+/// `&str` it will take a number of `char`'s, whereas for a `&[u8]` it will
+/// take that many `u8`'s:
+///
+/// ```rust
+/// use nom::error::Error;
+/// use nom::bytes::take;
+///
+/// assert_eq!(take::<_, _, Error<_>, false>(1usize)("💙"), Ok(("", "💙")));
+/// assert_eq!(take::<_, _, Error<_>, false>(1usize)("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take;
+///
+/// fn take6(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   take(6usize)(s)
+/// }
+///
+/// assert_eq!(take6(Streaming("1234567")), Ok((Streaming("7"), "123456")));
+/// assert_eq!(take6(Streaming("things")), Ok((Streaming(""), "things")));
+/// // `Unknown` as we don't know the number of bytes that `count` corresponds to
+/// assert_eq!(take6(Streaming("short")), Err(Err::Incomplete(Needed::Unknown)));
+/// ```
+#[inline(always)]
+pub fn take<C, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  count: C,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  C: ToUsize,
+{
+  let c = count.to_usize();
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_internal(i, c)
+    } else {
+      complete::take_internal(i, c)
+    }
+  }
+}
+
+/// Returns the input slice up to the first occurrence of the pattern.
+///
+/// It doesn't consume the pattern.
+///
+/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// if the pattern wasn't met.
+///
+/// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// contain the pattern or if the input is smaller than the pattern.
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take_until;
+///
+/// fn until_eof(s: &str) -> IResult<&str, &str> {
+///   take_until("eof")(s)
+/// }
+///
+/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_until;
+///
+/// fn until_eof(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   take_until("eof")(s)
+/// }
+///
+/// assert_eq!(until_eof(Streaming("hello, worldeof")), Ok((Streaming("eof"), "hello, world")));
+/// assert_eq!(until_eof(Streaming("hello, world")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("1eof2eof")), Ok((Streaming("eof2eof"), "1")));
+/// ```
+#[inline(always)]
+pub fn take_until<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  tag: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: InputLength + Clone,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_until_internal(i, tag.clone())
+    } else {
+      complete::take_until_internal(i, tag.clone())
+    }
+  }
+}
+
+/// Returns the non empty input slice up to the first occurrence of the pattern.
+///
+/// It doesn't consume the pattern.
+///
+/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// if the pattern wasn't met.
+///
+/// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// contain the pattern or if the input is smaller than the pattern.
+///
+/// # Example
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// use nom::bytes::take_until1;
+///
+/// fn until_eof(s: &str) -> IResult<&str, &str> {
+///   take_until1("eof")(s)
+/// }
+///
+/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// use nom::bytes::take_until1;
+///
+/// fn until_eof(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   take_until1("eof")(s)
+/// }
+///
+/// assert_eq!(until_eof(Streaming("hello, worldeof")), Ok((Streaming("eof"), "hello, world")));
+/// assert_eq!(until_eof(Streaming("hello, world")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("1eof2eof")), Ok((Streaming("eof2eof"), "1")));
+/// assert_eq!(until_eof(Streaming("eof")),  Err(Err::Error(Error::new(Streaming("eof"), ErrorKind::TakeUntil))));
+/// ```
+#[inline(always)]
+pub fn take_until1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  tag: T,
+) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  T: InputLength + Clone,
+{
+  move |i: Input| {
+    if STREAMING {
+      streaming::take_until1_internal(i, tag.clone())
+    } else {
+      complete::take_until1_internal(i, tag.clone())
+    }
+  }
+}
+
+/// Matches a byte string with escaped characters.
+///
+/// * The first argument matches the normal characters (it must not accept the control character)
+/// * The second argument is the control character (like `\` in most languages)
+/// * The third argument matches the escaped characters
+/// # Example
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::character::complete::digit1;
+/// use nom::bytes::escaped;
+/// use nom::character::complete::one_of;
+///
+/// fn esc(s: &str) -> IResult<&str, &str> {
+///   escaped(digit1, '\\', one_of(r#""n\"#))(s)
+/// }
+///
+/// assert_eq!(esc("123;"), Ok((";", "123")));
+/// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::character::streaming::digit1;
+/// # use nom::input::Streaming;
+/// use nom::bytes::escaped;
+/// use nom::character::streaming::one_of;
+///
+/// fn esc(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+///   escaped(digit1, '\\', one_of("\"n\\"))(s)
+/// }
+///
+/// assert_eq!(esc(Streaming("123;")), Ok((Streaming(";"), "123")));
+/// assert_eq!(esc(Streaming("12\\\"34;")), Ok((Streaming(";"), "12\\\"34")));
+/// ```
+#[inline(always)]
+pub fn escaped<'a, Input: 'a, Error, F, G, O1, O2, const STREAMING: bool>(
+  mut normal: F,
+  control_char: char,
+  mut escapable: G,
+) -> impl FnMut(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: Clone
+    + crate::input::Offset
+    + InputLength
+    + InputTake
+    + InputTakeAtPosition
+    + Slice<RangeFrom<usize>>
+    + InputIter
+    + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  <Input as InputIter>::Item: crate::input::AsChar,
+  F: Parser<Input, O1, Error>,
+  G: Parser<Input, O2, Error>,
+  Error: ParseError<Input>,
+{
+  move |input: Input| {
+    if STREAMING {
+      streaming::escaped_internal(input, &mut normal, control_char, &mut escapable)
+    } else {
+      complete::escaped_internal(input, &mut normal, control_char, &mut escapable)
+    }
+  }
+}
+
+/// Matches a byte string with escaped characters.
+///
+/// * The first argument matches the normal characters (it must not match the control character)
+/// * The second argument is the control character (like `\` in most languages)
+/// * The third argument matches the escaped characters and transforms them
+///
+/// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use std::str::from_utf8;
+/// use nom::bytes::{escaped_transform, tag};
+/// use nom::character::complete::alpha1;
+/// use nom::branch::alt;
+/// use nom::combinator::value;
+///
+/// fn parser(input: &str) -> IResult<&str, String> {
+///   escaped_transform(
+///     alpha1,
+///     '\\',
+///     alt((
+///       value("\\", tag("\\")),
+///       value("\"", tag("\"")),
+///       value("\n", tag("n")),
+///     ))
+///   )(input)
+/// }
+///
+/// assert_eq!(parser("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
+/// assert_eq!(parser("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use std::str::from_utf8;
+/// # use nom::input::Streaming;
+/// use nom::bytes::{escaped_transform, tag};
+/// use nom::character::streaming::alpha1;
+/// use nom::branch::alt;
+/// use nom::combinator::value;
+///
+/// fn parser(input: Streaming<&str>) -> IResult<Streaming<&str>, String> {
+///   escaped_transform(
+///     alpha1,
+///     '\\',
+///     alt((
+///       value("\\", tag("\\")),
+///       value("\"", tag("\"")),
+///       value("\n", tag("n")),
+///     ))
+///   )(input)
+/// }
+///
+/// assert_eq!(parser(Streaming("ab\\\"cd\"")), Ok((Streaming("\""), String::from("ab\"cd"))));
+/// ```
+#[cfg(feature = "alloc")]
+#[inline(always)]
+pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output, const STREAMING: bool>(
+  mut normal: F,
+  control_char: char,
+  mut transform: G,
+) -> impl FnMut(Input) -> IResult<Input, Output, Error>
+where
+  Input: Clone
+    + crate::input::Offset
+    + InputLength
+    + InputTake
+    + InputTakeAtPosition
+    + Slice<RangeFrom<usize>>
+    + InputIter
+    + InputIsStreaming<STREAMING>,
+  Input: IntoOutput,
+  Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  <Input as InputIter>::Item: crate::input::AsChar,
+  F: Parser<Input, O1, Error>,
+  G: Parser<Input, O2, Error>,
+  Error: ParseError<Input>,
+{
+  move |input: Input| {
+    if STREAMING {
+      streaming::escaped_transform_internal(input, &mut normal, control_char, &mut transform)
+    } else {
+      complete::escaped_transform_internal(input, &mut normal, control_char, &mut transform)
+    }
+  }
+}

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -1,5 +1,7 @@
 //! Parsers recognizing bytes streams, streaming version
 
+#![allow(deprecated)]
+
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
@@ -29,6 +31,12 @@ use crate::{Err, IResult, Needed, Parser};
 /// assert_eq!(parser("S"), Err(Err::Error(Error::new("S", ErrorKind::Tag))));
 /// assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::tag`][crate::bytes::tag] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::tag` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn tag<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -81,6 +89,12 @@ where
 /// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::tag_no_case`][crate::bytes::tag_no_case] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::tag_no_case` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn tag_no_case<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -135,6 +149,12 @@ where
 /// assert_eq!(not_space("Nospace"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(not_space(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_not`][crate::bytes::is_not] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::is_not` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -183,6 +203,12 @@ where
 /// assert_eq!(hex("D15EA5E"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(hex(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_a`][crate::bytes::is_a] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::is_a` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -230,6 +256,12 @@ where
 /// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(alpha(b""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while`][crate::bytes::take_while] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_while` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_while<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -277,6 +309,12 @@ where
 /// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while1`][crate::bytes::take_while1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_while1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_while1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -327,6 +365,12 @@ where
 /// assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while_m_n`][crate::bytes::take_while_m_n] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_while_m_n` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(
   m: usize,
   n: usize,
@@ -423,6 +467,12 @@ where
 /// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till`][crate::bytes::take_till] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_till` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_till<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -468,6 +518,12 @@ where
 /// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till1`][crate::bytes::take_till1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_till1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_till1<F, Input, Error: ParseError<Input>>(
   cond: F,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -515,6 +571,12 @@ where
 /// assert_eq!(take6("things"), Ok(("", "things")));
 /// assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take`][crate::bytes::take] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take<C, Input, Error: ParseError<Input>>(
   count: C,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -562,6 +624,12 @@ where
 /// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_until`][crate::bytes::take_until] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_until` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_until<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -610,6 +678,12 @@ where
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// assert_eq!(until_eof("eof"),  Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_until1`][crate::bytes::take_until1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::take_until1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn take_until1<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
@@ -657,6 +731,12 @@ where
 /// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
 /// ```
 ///
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::escaped`][crate::bytes::escaped] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::escaped` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn escaped<Input, Error, F, G, O1, O2>(
   mut normal: F,
   control_char: char,
@@ -780,6 +860,12 @@ where
 /// assert_eq!(parser("ab\\\"cd\""), Ok(("\"", String::from("ab\"cd"))));
 /// ```
 #[cfg(feature = "alloc")]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::escaped_transform`][crate::bytes::escaped_transform] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::bytes::escaped_transform` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
   mut normal: F,
   control_char: char,

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -8,7 +8,7 @@ use crate::input::{
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::*;
-use crate::IntoOutputIResult as _;
+use crate::IntoOutputIResult;
 use crate::{Err, IResult, Needed, Parser};
 
 /// Recognizes a pattern.
@@ -37,20 +37,29 @@ where
   Input: IntoOutput,
   T: InputLength + Clone,
 {
-  move |i: Input| {
-    let tag_len = tag.input_len();
-    let t = tag.clone();
+  move |i: Input| tag_internal(i, tag.clone())
+}
 
-    let res: IResult<_, _, Error> = match i.compare(t) {
-      CompareResult::Ok => Ok(i.take_split(tag_len)),
-      CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
-      CompareResult::Error => {
-        let e: ErrorKind = ErrorKind::Tag;
-        Err(Err::Error(Error::from_error_kind(i, e)))
-      }
-    };
-    res.into_output()
-  }
+pub(crate) fn tag_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  t: T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + Compare<T>,
+  Input: IntoOutput,
+  T: InputLength,
+{
+  let tag_len = t.input_len();
+
+  let res: IResult<_, _, Error> = match i.compare(t) {
+    CompareResult::Ok => Ok(i.take_split(tag_len)),
+    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Error => {
+      let e: ErrorKind = ErrorKind::Tag;
+      Err(Err::Error(Error::from_error_kind(i, e)))
+    }
+  };
+  res.into_output()
 }
 
 /// Recognizes a case insensitive pattern.
@@ -80,20 +89,29 @@ where
   Input: IntoOutput,
   T: InputLength + Clone,
 {
-  move |i: Input| {
-    let tag_len = tag.input_len();
-    let t = tag.clone();
+  move |i: Input| tag_no_case_internal(i, tag.clone())
+}
 
-    let res: IResult<_, _, Error> = match (i).compare_no_case(t) {
-      CompareResult::Ok => Ok(i.take_split(tag_len)),
-      CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
-      CompareResult::Error => {
-        let e: ErrorKind = ErrorKind::Tag;
-        Err(Err::Error(Error::from_error_kind(i, e)))
-      }
-    };
-    res.into_output()
-  }
+pub(crate) fn tag_no_case_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  t: T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + Compare<T>,
+  Input: IntoOutput,
+  T: InputLength,
+{
+  let tag_len = t.input_len();
+
+  let res: IResult<_, _, Error> = match (i).compare_no_case(t) {
+    CompareResult::Ok => Ok(i.take_split(tag_len)),
+    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Error => {
+      let e: ErrorKind = ErrorKind::Tag;
+      Err(Err::Error(Error::from_error_kind(i, e)))
+    }
+  };
+  res.into_output()
 }
 
 /// Parse till certain characters are met.
@@ -125,11 +143,21 @@ where
   Input: IntoOutput,
   T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| {
-    let e: ErrorKind = ErrorKind::IsNot;
-    i.split_at_position1_streaming(|c| arr.find_token(c), e)
-      .into_output()
-  }
+  move |i: Input| is_not_internal(i, &arr)
+}
+
+pub(crate) fn is_not_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  arr: &T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+{
+  let e: ErrorKind = ErrorKind::IsNot;
+  i.split_at_position1_streaming(|c| arr.find_token(c), e)
+    .into_output()
 }
 
 /// Returns the longest slice of the matches the pattern.
@@ -163,11 +191,21 @@ where
   Input: IntoOutput,
   T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| {
-    let e: ErrorKind = ErrorKind::IsA;
-    i.split_at_position1_streaming(|c| !arr.find_token(c), e)
-      .into_output()
-  }
+  move |i: Input| is_a_internal(i, &arr)
+}
+
+pub(crate) fn is_a_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  arr: &T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+{
+  let e: ErrorKind = ErrorKind::IsA;
+  i.split_at_position1_streaming(|c| !arr.find_token(c), e)
+    .into_output()
 }
 
 /// Returns the longest input slice (if any) that matches the predicate.
@@ -200,7 +238,19 @@ where
   Input: IntoOutput,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position_streaming(|c| !cond(c)).into_output()
+  move |i: Input| take_while_internal(i, &cond)
+}
+
+pub(crate) fn take_while_internal<F, Input, Error: ParseError<Input>>(
+  i: Input,
+  cond: &F,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  i.split_at_position_streaming(|c| !cond(c)).into_output()
 }
 
 /// Returns the longest (at least 1) input slice that matches the predicate.
@@ -235,11 +285,21 @@ where
   Input: IntoOutput,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| {
-    let e: ErrorKind = ErrorKind::TakeWhile1;
-    i.split_at_position1_streaming(|c| !cond(c), e)
-      .into_output()
-  }
+  move |i: Input| take_while1_internal(i, &cond)
+}
+
+pub(crate) fn take_while1_internal<F, Input, Error: ParseError<Input>>(
+  i: Input,
+  cond: &F,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  let e: ErrorKind = ErrorKind::TakeWhile1;
+  i.split_at_position1_streaming(|c| !cond(c), e)
+    .into_output()
 }
 
 /// Returns the longest (m <= len <= n) input slice  that matches the predicate.
@@ -277,52 +337,64 @@ where
   Input: IntoOutput,
   F: Fn(<Input as InputIter>::Item) -> bool,
 {
-  move |i: Input| {
-    let input = i;
+  move |i: Input| take_while_m_n_internal(i, m, n, &cond)
+}
 
-    match input.position(|c| !cond(c)) {
-      Some(idx) => {
-        if idx >= m {
-          if idx <= n {
-            let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(idx) {
-              Ok(input.take_split(index)).into_output()
-            } else {
-              Err(Err::Error(Error::from_error_kind(
-                input,
-                ErrorKind::TakeWhileMN,
-              )))
-            };
-            res
+pub(crate) fn take_while_m_n_internal<F, Input, Error: ParseError<Input>>(
+  i: Input,
+  m: usize,
+  n: usize,
+  cond: &F,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputIter + InputLength,
+  Input: IntoOutput,
+  F: Fn(<Input as InputIter>::Item) -> bool,
+{
+  let input = i;
+
+  match input.position(|c| !cond(c)) {
+    Some(idx) => {
+      if idx >= m {
+        if idx <= n {
+          let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(idx) {
+            Ok(input.take_split(index)).into_output()
           } else {
-            let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(n) {
-              Ok(input.take_split(index)).into_output()
-            } else {
-              Err(Err::Error(Error::from_error_kind(
-                input,
-                ErrorKind::TakeWhileMN,
-              )))
-            };
-            res
-          }
-        } else {
-          let e = ErrorKind::TakeWhileMN;
-          Err(Err::Error(Error::from_error_kind(input, e)))
-        }
-      }
-      None => {
-        let len = input.input_len();
-        if len >= n {
-          match input.slice_index(n) {
-            Ok(index) => Ok(input.take_split(index)).into_output(),
-            Err(_needed) => Err(Err::Error(Error::from_error_kind(
+            Err(Err::Error(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
-            ))),
-          }
+            )))
+          };
+          res
         } else {
-          let needed = if m > len { m - len } else { 1 };
-          Err(Err::Incomplete(Needed::new(needed)))
+          let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(n) {
+            Ok(input.take_split(index)).into_output()
+          } else {
+            Err(Err::Error(Error::from_error_kind(
+              input,
+              ErrorKind::TakeWhileMN,
+            )))
+          };
+          res
         }
+      } else {
+        let e = ErrorKind::TakeWhileMN;
+        Err(Err::Error(Error::from_error_kind(input, e)))
+      }
+    }
+    None => {
+      let len = input.input_len();
+      if len >= n {
+        match input.slice_index(n) {
+          Ok(index) => Ok(input.take_split(index)).into_output(),
+          Err(_needed) => Err(Err::Error(Error::from_error_kind(
+            input,
+            ErrorKind::TakeWhileMN,
+          ))),
+        }
+      } else {
+        let needed = if m > len { m - len } else { 1 };
+        Err(Err::Incomplete(Needed::new(needed)))
       }
     }
   }
@@ -359,7 +431,19 @@ where
   Input: IntoOutput,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| i.split_at_position_streaming(|c| cond(c)).into_output()
+  move |i: Input| take_till_internal(i, &cond)
+}
+
+pub(crate) fn take_till_internal<F, Input, Error: ParseError<Input>>(
+  i: Input,
+  cond: &F,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  i.split_at_position_streaming(|c| cond(c)).into_output()
 }
 
 /// Returns the longest (at least 1) input slice till a predicate is met.
@@ -392,10 +476,20 @@ where
   Input: IntoOutput,
   F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
-  move |i: Input| {
-    let e: ErrorKind = ErrorKind::TakeTill1;
-    i.split_at_position1_streaming(|c| cond(c), e).into_output()
-  }
+  move |i: Input| take_till1_internal(i, &cond)
+}
+
+pub(crate) fn take_till1_internal<F, Input, Error: ParseError<Input>>(
+  i: Input,
+  cond: &F,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTakeAtPosition,
+  Input: IntoOutput,
+  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+{
+  let e: ErrorKind = ErrorKind::TakeTill1;
+  i.split_at_position1_streaming(|c| cond(c), e).into_output()
 }
 
 /// Returns an input slice containing the first N input elements (Input[..N]).
@@ -430,7 +524,18 @@ where
   C: ToUsize,
 {
   let c = count.to_usize();
-  move |i: Input| match i.slice_index(c) {
+  move |i: Input| take_internal(i, c)
+}
+
+pub(crate) fn take_internal<Input, Error: ParseError<Input>>(
+  i: Input,
+  c: usize,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputIter + InputTake + InputLength,
+  Input: IntoOutput,
+{
+  match i.slice_index(c) {
     Err(i) => Err(Err::Incomplete(i)),
     Ok(index) => Ok(i.take_split(index)).into_output(),
   }
@@ -465,15 +570,22 @@ where
   Input: IntoOutput,
   T: Clone,
 {
-  move |i: Input| {
-    let t = tag.clone();
+  move |i: Input| take_until_internal(i, tag.clone())
+}
 
-    let res: IResult<_, _, Error> = match i.find_substring(t) {
-      None => Err(Err::Incomplete(Needed::Unknown)),
-      Some(index) => Ok(i.take_split(index)),
-    };
-    res.into_output()
-  }
+pub(crate) fn take_until_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  t: T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: IntoOutput,
+{
+  let res: IResult<_, _, Error> = match i.find_substring(t) {
+    None => Err(Err::Incomplete(Needed::Unknown)),
+    Some(index) => Ok(i.take_split(index)),
+  };
+  res.into_output()
 }
 
 /// Returns the non empty input slice up to the first occurrence of the pattern.
@@ -506,16 +618,23 @@ where
   Input: IntoOutput,
   T: Clone,
 {
-  move |i: Input| {
-    let t = tag.clone();
+  move |i: Input| take_until1_internal(i, tag.clone())
+}
 
-    let res: IResult<_, _, Error> = match i.find_substring(t) {
-      None => Err(Err::Incomplete(Needed::Unknown)),
-      Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
-      Some(index) => Ok(i.take_split(index)),
-    };
-    res.into_output()
-  }
+pub(crate) fn take_until1_internal<T, Input, Error: ParseError<Input>>(
+  i: Input,
+  t: T,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: IntoOutput,
+{
+  let res: IResult<_, _, Error> = match i.find_substring(t) {
+    None => Err(Err::Incomplete(Needed::Unknown)),
+    Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    Some(index) => Ok(i.take_split(index)),
+  };
+  res.into_output()
 }
 
 /// Matches a byte string with escaped characters.
@@ -557,56 +676,77 @@ where
   G: Parser<Input, O2, Error>,
   Error: ParseError<Input>,
 {
+  move |input: Input| escaped_internal(input, &mut normal, control_char, &mut escapable)
+}
+
+pub(crate) fn escaped_internal<Input, Error, F, G, O1, O2>(
+  input: Input,
+  normal: &mut F,
+  control_char: char,
+  escapable: &mut G,
+) -> IResult<Input, <Input as IntoOutput>::Output, Error>
+where
+  Input: Clone
+    + crate::input::Offset
+    + InputLength
+    + InputTake
+    + InputTakeAtPosition
+    + Slice<RangeFrom<usize>>
+    + InputIter,
+  Input: IntoOutput,
+  <Input as InputIter>::Item: crate::input::AsChar,
+  F: Parser<Input, O1, Error>,
+  G: Parser<Input, O2, Error>,
+  Error: ParseError<Input>,
+{
   use crate::input::AsChar;
 
-  move |input: Input| {
-    let mut i = input.clone();
+  let mut i = input.clone();
 
-    while i.input_len() > 0 {
-      let current_len = i.input_len();
+  while i.input_len() > 0 {
+    let current_len = i.input_len();
 
-      match normal.parse(i.clone()) {
-        Ok((i2, _)) => {
-          if i2.input_len() == 0 {
-            return Err(Err::Incomplete(Needed::Unknown));
-          } else if i2.input_len() == current_len {
-            let index = input.offset(&i2);
-            return Ok(input.take_split(index)).into_output();
-          } else {
-            i = i2;
-          }
-        }
-        Err(Err::Error(_)) => {
-          // unwrap() should be safe here since index < $i.input_len()
-          if i.iter_elements().next().unwrap().as_char() == control_char {
-            let next = control_char.len_utf8();
-            if next >= i.input_len() {
-              return Err(Err::Incomplete(Needed::new(1)));
-            } else {
-              match escapable.parse(i.slice(next..)) {
-                Ok((i2, _)) => {
-                  if i2.input_len() == 0 {
-                    return Err(Err::Incomplete(Needed::Unknown));
-                  } else {
-                    i = i2;
-                  }
-                }
-                Err(e) => return Err(e),
-              }
-            }
-          } else {
-            let index = input.offset(&i);
-            return Ok(input.take_split(index)).into_output();
-          }
-        }
-        Err(e) => {
-          return Err(e);
+    match normal.parse(i.clone()) {
+      Ok((i2, _)) => {
+        if i2.input_len() == 0 {
+          return Err(Err::Incomplete(Needed::Unknown));
+        } else if i2.input_len() == current_len {
+          let index = input.offset(&i2);
+          return Ok(input.take_split(index)).into_output();
+        } else {
+          i = i2;
         }
       }
+      Err(Err::Error(_)) => {
+        // unwrap() should be safe here since index < $i.input_len()
+        if i.iter_elements().next().unwrap().as_char() == control_char {
+          let next = control_char.len_utf8();
+          if next >= i.input_len() {
+            return Err(Err::Incomplete(Needed::new(1)));
+          } else {
+            match escapable.parse(i.slice(next..)) {
+              Ok((i2, _)) => {
+                if i2.input_len() == 0 {
+                  return Err(Err::Incomplete(Needed::Unknown));
+                } else {
+                  i = i2;
+                }
+              }
+              Err(e) => return Err(e),
+            }
+          }
+        } else {
+          let index = input.offset(&i);
+          return Ok(input.take_split(index)).into_output();
+        }
+      }
+      Err(e) => {
+        return Err(e);
+      }
     }
-
-    Err(Err::Incomplete(Needed::Unknown))
   }
+
+  Err(Err::Incomplete(Needed::Unknown))
 }
 
 /// Matches a byte string with escaped characters.
@@ -653,7 +793,32 @@ where
     + InputTakeAtPosition
     + Slice<RangeFrom<usize>>
     + InputIter,
-  Input: IntoOutput,
+  Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
+  <Input as InputIter>::Item: crate::input::AsChar,
+  F: Parser<Input, O1, Error>,
+  G: Parser<Input, O2, Error>,
+  Error: ParseError<Input>,
+{
+  move |input: Input| escaped_transform_internal(input, &mut normal, control_char, &mut transform)
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) fn escaped_transform_internal<Input, Error, F, G, O1, O2, ExtendItem, Output>(
+  input: Input,
+  normal: &mut F,
+  control_char: char,
+  transform: &mut G,
+) -> IResult<Input, Output, Error>
+where
+  Input: Clone
+    + crate::input::Offset
+    + InputLength
+    + InputTake
+    + InputTakeAtPosition
+    + Slice<RangeFrom<usize>>
+    + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
   O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
   O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
@@ -664,56 +829,54 @@ where
 {
   use crate::input::AsChar;
 
-  move |input: Input| {
-    let mut index = 0;
-    let mut res = input.new_builder();
+  let mut index = 0;
+  let mut res = input.new_builder();
 
-    let i = input.clone();
+  let i = input.clone();
 
-    while index < i.input_len() {
-      let current_len = i.input_len();
-      let remainder = i.slice(index..);
-      match normal.parse(remainder.clone()) {
-        Ok((i2, o)) => {
-          o.extend_into(&mut res);
-          if i2.input_len() == 0 {
-            return Err(Err::Incomplete(Needed::Unknown));
-          } else if i2.input_len() == current_len {
-            return Ok((remainder, res));
-          } else {
-            index = input.offset(&i2);
-          }
+  while index < i.input_len() {
+    let current_len = i.input_len();
+    let remainder = i.slice(index..);
+    match normal.parse(remainder.clone()) {
+      Ok((i2, o)) => {
+        o.extend_into(&mut res);
+        if i2.input_len() == 0 {
+          return Err(Err::Incomplete(Needed::Unknown));
+        } else if i2.input_len() == current_len {
+          return Ok((remainder, res));
+        } else {
+          index = input.offset(&i2);
         }
-        Err(Err::Error(_)) => {
-          // unwrap() should be safe here since index < $i.input_len()
-          if remainder.iter_elements().next().unwrap().as_char() == control_char {
-            let next = index + control_char.len_utf8();
-            let input_len = input.input_len();
-
-            if next >= input_len {
-              return Err(Err::Incomplete(Needed::Unknown));
-            } else {
-              match transform.parse(i.slice(next..)) {
-                Ok((i2, o)) => {
-                  o.extend_into(&mut res);
-                  if i2.input_len() == 0 {
-                    return Err(Err::Incomplete(Needed::Unknown));
-                  } else {
-                    index = input.offset(&i2);
-                  }
-                }
-                Err(e) => return Err(e),
-              }
-            }
-          } else {
-            return Ok((remainder, res));
-          }
-        }
-        Err(e) => return Err(e),
       }
+      Err(Err::Error(_)) => {
+        // unwrap() should be safe here since index < $i.input_len()
+        if remainder.iter_elements().next().unwrap().as_char() == control_char {
+          let next = index + control_char.len_utf8();
+          let input_len = input.input_len();
+
+          if next >= input_len {
+            return Err(Err::Incomplete(Needed::Unknown));
+          } else {
+            match transform.parse(i.slice(next..)) {
+              Ok((i2, o)) => {
+                o.extend_into(&mut res);
+                if i2.input_len() == 0 {
+                  return Err(Err::Incomplete(Needed::Unknown));
+                } else {
+                  index = input.offset(&i2);
+                }
+              }
+              Err(e) => return Err(e),
+            }
+          }
+        } else {
+          return Ok((remainder, res));
+        }
+      }
+      Err(e) => return Err(e),
     }
-    Err(Err::Incomplete(Needed::Unknown))
   }
+  Err(Err::Incomplete(Needed::Unknown))
 }
 
 #[cfg(test)]

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -34,7 +34,7 @@ fn complete_take_while_m_n_utf8_all_matching_substring() {
 fn complete_escaped_hang() {
   // issue #1336 "escaped hangs if normal parser accepts empty"
   fn escaped_string(input: &str) -> IResult<&str, &str> {
-    use crate::character::complete::{alpha0, one_of};
+    use crate::character::{alpha0, one_of};
     escaped(alpha0, '\\', one_of("n"))(input)
   }
 
@@ -46,7 +46,7 @@ fn complete_escaped_hang() {
 fn complete_escaped_hang_1118() {
   // issue ##1118 escaped does not work with empty string
   fn unquote<'a>(input: &'a str) -> IResult<&'a str, &'a str> {
-    use crate::character::complete::*;
+    use crate::character::*;
     use crate::combinator::opt;
     use crate::sequence::delimited;
 
@@ -64,8 +64,8 @@ fn complete_escaped_hang_1118() {
 #[allow(unused_variables)]
 #[test]
 fn complete_escaping() {
-  use crate::character::complete::one_of;
-  use crate::character::complete::{alpha1 as alpha, digit1 as digit};
+  use crate::character::one_of;
+  use crate::character::{alpha1 as alpha, digit1 as digit};
 
   fn esc(i: &[u8]) -> IResult<&[u8], &[u8]> {
     escaped(alpha, '\\', one_of("\"n\\"))(i)
@@ -100,8 +100,8 @@ fn complete_escaping() {
 #[cfg(feature = "alloc")]
 #[test]
 fn complete_escaping_str() {
-  use crate::character::complete::one_of;
-  use crate::character::complete::{alpha1 as alpha, digit1 as digit};
+  use crate::character::one_of;
+  use crate::character::{alpha1 as alpha, digit1 as digit};
 
   fn esc(i: &str) -> IResult<&str, &str> {
     escaped(alpha, '\\', one_of("\"n\\"))(i)
@@ -143,7 +143,7 @@ fn to_s(i: Vec<u8>) -> String {
 #[cfg(feature = "alloc")]
 #[test]
 fn complete_escape_transform() {
-  use crate::character::complete::alpha1 as alpha;
+  use crate::character::alpha1 as alpha;
 
   fn esc(i: &[u8]) -> IResult<&[u8], String> {
     map(
@@ -216,7 +216,7 @@ fn complete_escape_transform() {
 #[cfg(feature = "std")]
 #[test]
 fn complete_escape_transform_str() {
-  use crate::character::complete::alpha1 as alpha;
+  use crate::character::alpha1 as alpha;
 
   fn esc(i: &str) -> IResult<&str, String> {
     escaped_transform(
@@ -353,7 +353,7 @@ fn streaming_take_until_incomplete_s() {
 
 #[test]
 fn streaming_recognize() {
-  use crate::character::streaming::{
+  use crate::character::{
     alpha1 as alpha, alphanumeric1 as alphanumeric, digit1 as digit, hex_digit1 as hex_digit,
     multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
   };
@@ -611,7 +611,7 @@ fn streaming_recognize_take_while() {
 
 #[test]
 fn streaming_length_bytes() {
-  use crate::number::streaming::le_u8;
+  use crate::number::le_u8;
 
   fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     length_data(le_u8)(i)

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -1,0 +1,732 @@
+use super::*;
+
+use crate::combinator::recognize;
+use crate::error::ErrorKind;
+use crate::input::AsChar;
+use crate::input::Streaming;
+use crate::multi::length_data;
+use crate::sequence::delimited;
+use crate::Err;
+use crate::IResult;
+use crate::Needed;
+#[cfg(feature = "alloc")]
+use crate::{
+  branch::alt,
+  combinator::{map, value},
+  lib::std::string::String,
+  lib::std::vec::Vec,
+};
+
+#[test]
+fn complete_take_while_m_n_utf8_all_matching() {
+  let result: IResult<&str, &str> = super::take_while_m_n(1, 4, |c: char| c.is_alphabetic())("øn");
+  assert_eq!(result, Ok(("", "øn")));
+}
+
+#[test]
+fn complete_take_while_m_n_utf8_all_matching_substring() {
+  let result: IResult<&str, &str> = super::take_while_m_n(1, 1, |c: char| c.is_alphabetic())("øn");
+  assert_eq!(result, Ok(("n", "ø")));
+}
+
+// issue #1336 "escaped hangs if normal parser accepts empty"
+#[test]
+fn complete_escaped_hang() {
+  // issue #1336 "escaped hangs if normal parser accepts empty"
+  fn escaped_string(input: &str) -> IResult<&str, &str> {
+    use crate::character::complete::{alpha0, one_of};
+    escaped(alpha0, '\\', one_of("n"))(input)
+  }
+
+  escaped_string("7").unwrap();
+  escaped_string("a7").unwrap();
+}
+
+#[test]
+fn complete_escaped_hang_1118() {
+  // issue ##1118 escaped does not work with empty string
+  fn unquote<'a>(input: &'a str) -> IResult<&'a str, &'a str> {
+    use crate::character::complete::*;
+    use crate::combinator::opt;
+    use crate::sequence::delimited;
+
+    delimited(
+      char('"'),
+      escaped(opt(none_of(r#"\""#)), '\\', one_of(r#"\"rnt"#)),
+      char('"'),
+    )(input)
+  }
+
+  assert_eq!(unquote(r#""""#), Ok(("", "")));
+}
+
+#[cfg(feature = "alloc")]
+#[allow(unused_variables)]
+#[test]
+fn complete_escaping() {
+  use crate::character::complete::one_of;
+  use crate::character::complete::{alpha1 as alpha, digit1 as digit};
+
+  fn esc(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    escaped(alpha, '\\', one_of("\"n\\"))(i)
+  }
+  assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], &b"abcd"[..])));
+  assert_eq!(esc(&b"ab\\\"cd;"[..]), Ok((&b";"[..], &b"ab\\\"cd"[..])));
+  assert_eq!(esc(&b"\\\"abcd;"[..]), Ok((&b";"[..], &b"\\\"abcd"[..])));
+  assert_eq!(esc(&b"\\n;"[..]), Ok((&b";"[..], &b"\\n"[..])));
+  assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], &b"ab\\\""[..])));
+  assert_eq!(
+    esc(&b"AB\\"[..]),
+    Err(Err::Error(error_position!(
+      &b"AB\\"[..],
+      ErrorKind::Escaped
+    )))
+  );
+  assert_eq!(
+    esc(&b"AB\\A"[..]),
+    Err(Err::Error(error_node_position!(
+      &b"AB\\A"[..],
+      ErrorKind::Escaped,
+      error_position!(&b"A"[..], ErrorKind::OneOf)
+    )))
+  );
+
+  fn esc2(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    escaped(digit, '\\', one_of("\"n\\"))(i)
+  }
+  assert_eq!(esc2(&b"12\\nnn34"[..]), Ok((&b"nn34"[..], &b"12\\n"[..])));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn complete_escaping_str() {
+  use crate::character::complete::one_of;
+  use crate::character::complete::{alpha1 as alpha, digit1 as digit};
+
+  fn esc(i: &str) -> IResult<&str, &str> {
+    escaped(alpha, '\\', one_of("\"n\\"))(i)
+  }
+  assert_eq!(esc("abcd;"), Ok((";", "abcd")));
+  assert_eq!(esc("ab\\\"cd;"), Ok((";", "ab\\\"cd")));
+  assert_eq!(esc("\\\"abcd;"), Ok((";", "\\\"abcd")));
+  assert_eq!(esc("\\n;"), Ok((";", "\\n")));
+  assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
+  assert_eq!(
+    esc("AB\\"),
+    Err(Err::Error(error_position!("AB\\", ErrorKind::Escaped)))
+  );
+  assert_eq!(
+    esc("AB\\A"),
+    Err(Err::Error(error_node_position!(
+      "AB\\A",
+      ErrorKind::Escaped,
+      error_position!("A", ErrorKind::OneOf)
+    )))
+  );
+
+  fn esc2(i: &str) -> IResult<&str, &str> {
+    escaped(digit, '\\', one_of("\"n\\"))(i)
+  }
+  assert_eq!(esc2("12\\nnn34"), Ok(("nn34", "12\\n")));
+
+  fn esc3(i: &str) -> IResult<&str, &str> {
+    escaped(alpha, '\u{241b}', one_of("\"n"))(i)
+  }
+  assert_eq!(esc3("ab␛ncd;"), Ok((";", "ab␛ncd")));
+}
+
+#[cfg(feature = "alloc")]
+fn to_s(i: Vec<u8>) -> String {
+  String::from_utf8_lossy(&i).into_owned()
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn complete_escape_transform() {
+  use crate::character::complete::alpha1 as alpha;
+
+  fn esc(i: &[u8]) -> IResult<&[u8], String> {
+    map(
+      escaped_transform(
+        alpha,
+        '\\',
+        alt((
+          value(&b"\\"[..], tag("\\")),
+          value(&b"\""[..], tag("\"")),
+          value(&b"\n"[..], tag("n")),
+        )),
+      ),
+      to_s,
+    )(i)
+  }
+
+  assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], String::from("abcd"))));
+  assert_eq!(
+    esc(&b"ab\\\"cd;"[..]),
+    Ok((&b";"[..], String::from("ab\"cd")))
+  );
+  assert_eq!(
+    esc(&b"\\\"abcd;"[..]),
+    Ok((&b";"[..], String::from("\"abcd")))
+  );
+  assert_eq!(esc(&b"\\n;"[..]), Ok((&b";"[..], String::from("\n"))));
+  assert_eq!(
+    esc(&b"ab\\\"12"[..]),
+    Ok((&b"12"[..], String::from("ab\"")))
+  );
+  assert_eq!(
+    esc(&b"AB\\"[..]),
+    Err(Err::Error(error_position!(
+      &b"\\"[..],
+      ErrorKind::EscapedTransform
+    )))
+  );
+  assert_eq!(
+    esc(&b"AB\\A"[..]),
+    Err(Err::Error(error_node_position!(
+      &b"AB\\A"[..],
+      ErrorKind::EscapedTransform,
+      error_position!(&b"A"[..], ErrorKind::Tag)
+    )))
+  );
+
+  fn esc2(i: &[u8]) -> IResult<&[u8], String> {
+    map(
+      escaped_transform(
+        alpha,
+        '&',
+        alt((
+          value("è".as_bytes(), tag("egrave;")),
+          value("à".as_bytes(), tag("agrave;")),
+        )),
+      ),
+      to_s,
+    )(i)
+  }
+  assert_eq!(
+    esc2(&b"ab&egrave;DEF;"[..]),
+    Ok((&b";"[..], String::from("abèDEF")))
+  );
+  assert_eq!(
+    esc2(&b"ab&egrave;D&agrave;EF;"[..]),
+    Ok((&b";"[..], String::from("abèDàEF")))
+  );
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn complete_escape_transform_str() {
+  use crate::character::complete::alpha1 as alpha;
+
+  fn esc(i: &str) -> IResult<&str, String> {
+    escaped_transform(
+      alpha,
+      '\\',
+      alt((
+        value("\\", tag("\\")),
+        value("\"", tag("\"")),
+        value("\n", tag("n")),
+      )),
+    )(i)
+  }
+
+  assert_eq!(esc("abcd;"), Ok((";", String::from("abcd"))));
+  assert_eq!(esc("ab\\\"cd;"), Ok((";", String::from("ab\"cd"))));
+  assert_eq!(esc("\\\"abcd;"), Ok((";", String::from("\"abcd"))));
+  assert_eq!(esc("\\n;"), Ok((";", String::from("\n"))));
+  assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
+  assert_eq!(
+    esc("AB\\"),
+    Err(Err::Error(error_position!(
+      "\\",
+      ErrorKind::EscapedTransform
+    )))
+  );
+  assert_eq!(
+    esc("AB\\A"),
+    Err(Err::Error(error_node_position!(
+      "AB\\A",
+      ErrorKind::EscapedTransform,
+      error_position!("A", ErrorKind::Tag)
+    )))
+  );
+
+  fn esc2(i: &str) -> IResult<&str, String> {
+    escaped_transform(
+      alpha,
+      '&',
+      alt((value("è", tag("egrave;")), value("à", tag("agrave;")))),
+    )(i)
+  }
+  assert_eq!(esc2("ab&egrave;DEF;"), Ok((";", String::from("abèDEF"))));
+  assert_eq!(
+    esc2("ab&egrave;D&agrave;EF;"),
+    Ok((";", String::from("abèDàEF")))
+  );
+
+  fn esc3(i: &str) -> IResult<&str, String> {
+    escaped_transform(
+      alpha,
+      '␛',
+      alt((value("\0", tag("0")), value("\n", tag("n")))),
+    )(i)
+  }
+  assert_eq!(esc3("a␛0bc␛n"), Ok(("", String::from("a\0bc\n"))));
+}
+
+#[test]
+fn streaming_is_a() {
+  fn a_or_b(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    is_a("ab")(i)
+  }
+
+  let a = Streaming(&b"abcd"[..]);
+  assert_eq!(a_or_b(a), Ok((Streaming(&b"cd"[..]), &b"ab"[..])));
+
+  let b = Streaming(&b"bcde"[..]);
+  assert_eq!(a_or_b(b), Ok((Streaming(&b"cde"[..]), &b"b"[..])));
+
+  let c = Streaming(&b"cdef"[..]);
+  assert_eq!(
+    a_or_b(c),
+    Err(Err::Error(error_position!(c, ErrorKind::IsA)))
+  );
+
+  let d = Streaming(&b"bacdef"[..]);
+  assert_eq!(a_or_b(d), Ok((Streaming(&b"cdef"[..]), &b"ba"[..])));
+}
+
+#[test]
+fn streaming_is_not() {
+  fn a_or_b(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    is_not("ab")(i)
+  }
+
+  let a = Streaming(&b"cdab"[..]);
+  assert_eq!(a_or_b(a), Ok((Streaming(&b"ab"[..]), &b"cd"[..])));
+
+  let b = Streaming(&b"cbde"[..]);
+  assert_eq!(a_or_b(b), Ok((Streaming(&b"bde"[..]), &b"c"[..])));
+
+  let c = Streaming(&b"abab"[..]);
+  assert_eq!(
+    a_or_b(c),
+    Err(Err::Error(error_position!(c, ErrorKind::IsNot)))
+  );
+
+  let d = Streaming(&b"cdefba"[..]);
+  assert_eq!(a_or_b(d), Ok((Streaming(&b"ba"[..]), &b"cdef"[..])));
+
+  let e = Streaming(&b"e"[..]);
+  assert_eq!(a_or_b(e), Err(Err::Incomplete(Needed::new(1))));
+}
+
+#[test]
+fn streaming_take_until_incomplete() {
+  fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_until("end")(i)
+  }
+  assert_eq!(
+    y(Streaming(&b"nd"[..])),
+    Err(Err::Incomplete(Needed::Unknown))
+  );
+  assert_eq!(
+    y(Streaming(&b"123"[..])),
+    Err(Err::Incomplete(Needed::Unknown))
+  );
+  assert_eq!(
+    y(Streaming(&b"123en"[..])),
+    Err(Err::Incomplete(Needed::Unknown))
+  );
+}
+
+#[test]
+fn streaming_take_until_incomplete_s() {
+  fn ys(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_until("end")(i)
+  }
+  assert_eq!(
+    ys(Streaming("123en")),
+    Err(Err::Incomplete(Needed::Unknown))
+  );
+}
+
+#[test]
+fn streaming_recognize() {
+  use crate::character::streaming::{
+    alpha1 as alpha, alphanumeric1 as alphanumeric, digit1 as digit, hex_digit1 as hex_digit,
+    multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
+  };
+
+  fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(delimited(tag("<!--"), take(5_usize), tag("-->")))(i)
+  }
+  let r = x(Streaming(&b"<!-- abc --> aaa"[..]));
+  assert_eq!(r, Ok((Streaming(&b" aaa"[..]), &b"<!-- abc -->"[..])));
+
+  let semicolon = &b";"[..];
+
+  fn ya(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(alpha)(i)
+  }
+  let ra = ya(Streaming(&b"abc;"[..]));
+  assert_eq!(ra, Ok((Streaming(semicolon), &b"abc"[..])));
+
+  fn yd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(digit)(i)
+  }
+  let rd = yd(Streaming(&b"123;"[..]));
+  assert_eq!(rd, Ok((Streaming(semicolon), &b"123"[..])));
+
+  fn yhd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(hex_digit)(i)
+  }
+  let rhd = yhd(Streaming(&b"123abcDEF;"[..]));
+  assert_eq!(rhd, Ok((Streaming(semicolon), &b"123abcDEF"[..])));
+
+  fn yod(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(oct_digit)(i)
+  }
+  let rod = yod(Streaming(&b"1234567;"[..]));
+  assert_eq!(rod, Ok((Streaming(semicolon), &b"1234567"[..])));
+
+  fn yan(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(alphanumeric)(i)
+  }
+  let ran = yan(Streaming(&b"123abc;"[..]));
+  assert_eq!(ran, Ok((Streaming(semicolon), &b"123abc"[..])));
+
+  fn ys(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(space)(i)
+  }
+  let rs = ys(Streaming(&b" \t;"[..]));
+  assert_eq!(rs, Ok((Streaming(semicolon), &b" \t"[..])));
+
+  fn yms(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(multispace)(i)
+  }
+  let rms = yms(Streaming(&b" \t\r\n;"[..]));
+  assert_eq!(rms, Ok((Streaming(semicolon), &b" \t\r\n"[..])));
+}
+
+#[test]
+fn streaming_take_while() {
+  fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_while(AsChar::is_alpha)(i)
+  }
+  let a = &b""[..];
+  let b = &b"abcd"[..];
+  let c = &b"abcd123"[..];
+  let d = &b"123"[..];
+
+  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(c)), Ok((Streaming(d), b)));
+  assert_eq!(f(Streaming(d)), Ok((Streaming(d), a)));
+}
+
+#[test]
+fn streaming_take_while1() {
+  fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_while1(AsChar::is_alpha)(i)
+  }
+  let a = &b""[..];
+  let b = &b"abcd"[..];
+  let c = &b"abcd123"[..];
+  let d = &b"123"[..];
+
+  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(c)), Ok((Streaming(&b"123"[..]), b)));
+  assert_eq!(
+    f(Streaming(d)),
+    Err(Err::Error(error_position!(
+      Streaming(d),
+      ErrorKind::TakeWhile1
+    )))
+  );
+}
+
+#[test]
+fn streaming_take_while_m_n() {
+  fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_while_m_n(2, 4, AsChar::is_alpha)(i)
+  }
+  let a = &b""[..];
+  let b = &b"a"[..];
+  let c = &b"abc"[..];
+  let d = &b"abc123"[..];
+  let e = &b"abcde"[..];
+  let f = &b"123"[..];
+
+  assert_eq!(x(Streaming(a)), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(x(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(x(Streaming(c)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(x(Streaming(d)), Ok((Streaming(&b"123"[..]), c)));
+  assert_eq!(x(Streaming(e)), Ok((Streaming(&b"e"[..]), &b"abcd"[..])));
+  assert_eq!(
+    x(Streaming(f)),
+    Err(Err::Error(error_position!(
+      Streaming(f),
+      ErrorKind::TakeWhileMN
+    )))
+  );
+}
+
+#[test]
+fn streaming_take_till() {
+  fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_till(AsChar::is_alpha)(i)
+  }
+  let a = &b""[..];
+  let b = &b"abcd"[..];
+  let c = &b"123abcd"[..];
+  let d = &b"123"[..];
+
+  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(b)), Ok((Streaming(&b"abcd"[..]), &b""[..])));
+  assert_eq!(f(Streaming(c)), Ok((Streaming(&b"abcd"[..]), &b"123"[..])));
+  assert_eq!(f(Streaming(d)), Err(Err::Incomplete(Needed::new(1))));
+}
+
+#[test]
+fn streaming_take_till1() {
+  fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_till1(AsChar::is_alpha)(i)
+  }
+  let a = &b""[..];
+  let b = &b"abcd"[..];
+  let c = &b"123abcd"[..];
+  let d = &b"123"[..];
+
+  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(
+    f(Streaming(b)),
+    Err(Err::Error(error_position!(
+      Streaming(b),
+      ErrorKind::TakeTill1
+    )))
+  );
+  assert_eq!(f(Streaming(c)), Ok((Streaming(&b"abcd"[..]), &b"123"[..])));
+  assert_eq!(f(Streaming(d)), Err(Err::Incomplete(Needed::new(1))));
+}
+
+#[test]
+fn streaming_take_while_utf8() {
+  fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while(|c| c != '點')(i)
+  }
+
+  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("abcd點")), Ok((Streaming("點"), "abcd")));
+  assert_eq!(f(Streaming("abcd點a")), Ok((Streaming("點a"), "abcd")));
+
+  fn g(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while(|c| c == '點')(i)
+  }
+
+  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
+  assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
+}
+
+#[test]
+fn streaming_take_till_utf8() {
+  fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_till(|c| c == '點')(i)
+  }
+
+  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("abcd點")), Ok((Streaming("點"), "abcd")));
+  assert_eq!(f(Streaming("abcd點a")), Ok((Streaming("點a"), "abcd")));
+
+  fn g(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_till(|c| c != '點')(i)
+  }
+
+  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
+  assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
+}
+
+#[test]
+fn streaming_take_utf8() {
+  fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take(3_usize)(i)
+  }
+
+  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
+  assert_eq!(f(Streaming("ab")), Err(Err::Incomplete(Needed::Unknown)));
+  assert_eq!(f(Streaming("點")), Err(Err::Incomplete(Needed::Unknown)));
+  assert_eq!(f(Streaming("ab點cd")), Ok((Streaming("cd"), "ab點")));
+  assert_eq!(f(Streaming("a點bcd")), Ok((Streaming("cd"), "a點b")));
+  assert_eq!(f(Streaming("a點b")), Ok((Streaming(""), "a點b")));
+
+  fn g(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while(|c| c == '點')(i)
+  }
+
+  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
+  assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
+}
+
+#[test]
+fn streaming_take_while_m_n_utf8() {
+  fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while_m_n(1, 1, |c| c == 'A' || c == '😃')(i)
+  }
+  assert_eq!(parser(Streaming("A!")), Ok((Streaming("!"), "A")));
+  assert_eq!(parser(Streaming("😃!")), Ok((Streaming("!"), "😃")));
+}
+
+#[test]
+fn streaming_take_while_m_n_utf8_full_match() {
+  fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while_m_n(1, 1, |c: char| c.is_alphabetic())(i)
+  }
+  assert_eq!(parser(Streaming("øn")), Ok((Streaming("n"), "ø")));
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn streaming_recognize_take_while() {
+  fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    take_while(AsChar::is_alphanum)(i)
+  }
+  fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    recognize(x)(i)
+  }
+  assert_eq!(
+    x(Streaming(&b"ab."[..])),
+    Ok((Streaming(&b"."[..]), &b"ab"[..]))
+  );
+  assert_eq!(
+    y(Streaming(&b"ab."[..])),
+    Ok((Streaming(&b"."[..]), &b"ab"[..]))
+  );
+}
+
+#[test]
+fn streaming_length_bytes() {
+  use crate::number::streaming::le_u8;
+
+  fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    length_data(le_u8)(i)
+  }
+  assert_eq!(
+    x(Streaming(b"\x02..>>")),
+    Ok((Streaming(&b">>"[..]), &b".."[..]))
+  );
+  assert_eq!(
+    x(Streaming(b"\x02..")),
+    Ok((Streaming(&[][..]), &b".."[..]))
+  );
+  assert_eq!(x(Streaming(b"\x02.")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(x(Streaming(b"\x02")), Err(Err::Incomplete(Needed::new(2))));
+
+  fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    let (i, _) = tag("magic")(i)?;
+    length_data(le_u8)(i)
+  }
+  assert_eq!(
+    y(Streaming(b"magic\x02..>>")),
+    Ok((Streaming(&b">>"[..]), &b".."[..]))
+  );
+  assert_eq!(
+    y(Streaming(b"magic\x02..")),
+    Ok((Streaming(&[][..]), &b".."[..]))
+  );
+  assert_eq!(
+    y(Streaming(b"magic\x02.")),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    y(Streaming(b"magic\x02")),
+    Err(Err::Incomplete(Needed::new(2)))
+  );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn streaming_case_insensitive() {
+  fn test(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    tag_no_case("ABcd")(i)
+  }
+  assert_eq!(
+    test(Streaming(&b"aBCdefgh"[..])),
+    Ok((Streaming(&b"efgh"[..]), &b"aBCd"[..]))
+  );
+  assert_eq!(
+    test(Streaming(&b"abcdefgh"[..])),
+    Ok((Streaming(&b"efgh"[..]), &b"abcd"[..]))
+  );
+  assert_eq!(
+    test(Streaming(&b"ABCDefgh"[..])),
+    Ok((Streaming(&b"efgh"[..]), &b"ABCD"[..]))
+  );
+  assert_eq!(
+    test(Streaming(&b"ab"[..])),
+    Err(Err::Incomplete(Needed::new(2)))
+  );
+  assert_eq!(
+    test(Streaming(&b"Hello"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"Hello"[..]),
+      ErrorKind::Tag
+    )))
+  );
+  assert_eq!(
+    test(Streaming(&b"Hel"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"Hel"[..]),
+      ErrorKind::Tag
+    )))
+  );
+
+  fn test2(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    tag_no_case("ABcd")(i)
+  }
+  assert_eq!(
+    test2(Streaming("aBCdefgh")),
+    Ok((Streaming("efgh"), "aBCd"))
+  );
+  assert_eq!(
+    test2(Streaming("abcdefgh")),
+    Ok((Streaming("efgh"), "abcd"))
+  );
+  assert_eq!(
+    test2(Streaming("ABCDefgh")),
+    Ok((Streaming("efgh"), "ABCD"))
+  );
+  assert_eq!(test2(Streaming("ab")), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(
+    test2(Streaming("Hello")),
+    Err(Err::Error(error_position!(
+      Streaming("Hello"),
+      ErrorKind::Tag
+    )))
+  );
+  assert_eq!(
+    test2(Streaming("Hel")),
+    Err(Err::Error(error_position!(
+      Streaming("Hel"),
+      ErrorKind::Tag
+    )))
+  );
+}
+
+#[test]
+fn streaming_tag_fixed_size_array() {
+  fn test(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    tag([0x42])(i)
+  }
+  fn test2(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    tag(&[0x42])(i)
+  }
+  let input = Streaming(&[0x42, 0x00][..]);
+  assert_eq!(test(input), Ok((Streaming(&b"\x00"[..]), &b"\x42"[..])));
+  assert_eq!(test2(input), Ok((Streaming(&b"\x00"[..]), &b"\x42"[..])));
+}

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -2,6 +2,8 @@
 //!
 //! Functions recognizing specific characters.
 
+#![allow(deprecated)]
+
 use crate::branch::alt;
 use crate::combinator::opt;
 use crate::error::ErrorKind;
@@ -30,6 +32,9 @@ use crate::{Err, IResult};
 /// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::char`][crate::character::char]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::char`")]
 pub fn char<I, Error: ParseError<I>>(c: char) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -67,6 +72,9 @@ where
 /// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::satisfy`][crate::character::satisfy]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::satisfy`")]
 pub fn satisfy<F, I, Error: ParseError<I>>(cond: F) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -107,6 +115,9 @@ where
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::one_of`][crate::character::one_of]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::one_of`")]
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -140,6 +151,9 @@ where
 /// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
 /// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::none_of`][crate::character::none_of]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::none_of`")]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -180,6 +194,9 @@ where
 /// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::crlf`][crate::character::crlf]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::crlf`")]
 pub fn crlf<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>>,
@@ -217,6 +234,12 @@ where
 /// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", code: ErrorKind::Tag })));
 /// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", code: ErrorKind::Tag })));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::not_line_ending`][crate::character::not_line_ending]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::not_line_ending`"
+)]
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -268,6 +291,9 @@ where
 /// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::line_ending`][crate::character::line_ending]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::line_ending`")]
 pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -304,6 +330,9 @@ where
 /// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::newline`][crate::character::newline]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::newline`")]
 pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -328,6 +357,9 @@ where
 /// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::tab`][crate::character::tab]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::tab`")]
 pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -351,6 +383,9 @@ where
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::anychar`][crate::character::anychar]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::anychar`")]
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
   T: InputIter + InputLength + Slice<RangeFrom<usize>>,
@@ -383,6 +418,9 @@ where
 /// assert_eq!(parser("1c"), Ok(("1c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alpha0`][crate::character::alpha0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::alpha0`")]
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -411,6 +449,9 @@ where
 /// assert_eq!(parser("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Alpha))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alpha1`][crate::character::alpha1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::alpha1`")]
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -440,6 +481,9 @@ where
 /// assert_eq!(parser("a21c"), Ok(("a21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::digit0`][crate::character::digit0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::digit0`")]
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -486,6 +530,9 @@ where
 /// ```
 ///
 /// [`map_res`]: crate::combinator::map_res
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::digit1`][crate::character::digit1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::digit1`")]
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -513,6 +560,9 @@ where
 /// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::hex_digit0`][crate::character::hex_digit0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::hex_digit0`")]
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -540,6 +590,9 @@ where
 /// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::HexDigit))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::hex_digit1`][crate::character::hex_digit1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::hex_digit1`")]
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -568,6 +621,9 @@ where
 /// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::oct_digit0`][crate::character::oct_digit0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::oct_digit0`")]
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -596,6 +652,9 @@ where
 /// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OctDigit))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::oct_digit1`][crate::character::oct_digit1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::oct_digit1`")]
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -624,6 +683,12 @@ where
 /// assert_eq!(parser("&Z21c"), Ok(("&Z21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alphanumeric0`][crate::character::alphanumeric0]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alphanumeric0`"
+)]
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -652,6 +717,12 @@ where
 /// assert_eq!(parser("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alphanumeric1`][crate::character::alphanumeric1]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alphanumeric1`"
+)]
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -680,6 +751,9 @@ where
 /// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::space0`][crate::character::space0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::space0`")]
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -711,6 +785,9 @@ where
 /// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Space))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::space1`][crate::character::space1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::space1`")]
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -745,6 +822,9 @@ where
 /// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::multispace0`][crate::character::multispace0]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::multispace0`")]
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -776,6 +856,9 @@ where
 /// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::MultiSpace))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::multispace1`][crate::character::multispace1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::multispace1`")]
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -4,6 +4,1167 @@
 
 pub mod complete;
 pub mod streaming;
+#[cfg(test)]
+mod tests;
+
+use crate::error::ParseError;
+use crate::input::Compare;
+use crate::input::{
+  AsChar, FindToken, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtPosition,
+  IntoOutput, Slice,
+};
+use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
+use crate::IResult;
+
+/// Recognizes one character.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{ErrorKind, Error}, IResult};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     char('a')(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// # use nom::character::char;
+/// fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+///     char('a')(i)
+/// }
+/// assert_eq!(parser(Streaming("abc")), Ok((Streaming("bc"), 'a')));
+/// assert_eq!(parser(Streaming("bc")), Err(Err::Error(Error::new(Streaming("bc"), ErrorKind::Char))));
+/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn char<I, Error: ParseError<I>, const STREAMING: bool>(
+  c: char,
+) -> impl Fn(I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar,
+{
+  move |i: I| {
+    if STREAMING {
+      streaming::char_internal(i, c)
+    } else {
+      complete::char_internal(i, c)
+    }
+  }
+}
+
+/// Recognizes one character and checks that it satisfies a predicate
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use nom::character::satisfy;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     satisfy(|c| c == 'a' || c == 'b')(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use nom::input::Streaming;
+/// # use nom::character::satisfy;
+/// fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+///     satisfy(|c| c == 'a' || c == 'b')(i)
+/// }
+/// assert_eq!(parser(Streaming("abc")), Ok((Streaming("bc"), 'a')));
+/// assert_eq!(parser(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::Satisfy))));
+/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
+/// ```
+#[inline(always)]
+pub fn satisfy<F, I, Error: ParseError<I>, const STREAMING: bool>(
+  cond: F,
+) -> impl Fn(I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar,
+  F: Fn(char) -> bool,
+{
+  move |i: I| {
+    if STREAMING {
+      streaming::satisfy_internal(i, &cond)
+    } else {
+      complete::satisfy_internal(i, &cond)
+    }
+  }
+}
+
+/// Recognizes one of the provided characters.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind};
+/// # use nom::character::one_of;
+/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("abc")("b"), Ok(("", 'b')));
+/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::one_of;
+/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
+/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("bc")), Err(Err::Error((Streaming("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
+  list: T,
+) -> impl Fn(I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar + Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  move |i: I| {
+    if STREAMING {
+      streaming::one_of_internal(i, &list)
+    } else {
+      complete::one_of_internal(i, &list)
+    }
+  }
+}
+
+/// Recognizes a character that is not in the provided characters.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind};
+/// # use nom::character::none_of;
+/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("abc")("z"), Ok(("", 'z')));
+/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::none_of;
+/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
+/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("ab")(Streaming("a")), Err(Err::Error((Streaming("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
+  list: T,
+) -> impl Fn(I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar + Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  move |i: I| {
+    if STREAMING {
+      streaming::none_of_internal(i, &list)
+    } else {
+      complete::none_of_internal(i, &list)
+    }
+  }
+}
+
+/// Recognizes the string "\r\n".
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult};
+/// # use nom::character::crlf;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     crlf(input)
+/// }
+///
+/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::crlf;
+/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
+/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Err(Err::Error((Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn crlf<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  T: InputIter + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  T: Compare<&'static str>,
+{
+  if STREAMING {
+    streaming::crlf(input)
+  } else {
+    complete::crlf(input)
+  }
+}
+
+/// Recognizes a string of any char except '\r\n' or '\n'.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::not_line_ending;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     not_line_ending(input)
+/// }
+///
+/// assert_eq!(parser("ab\r\nc"), Ok(("\r\nc", "ab")));
+/// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
+/// assert_eq!(parser("abc"), Ok(("", "abc")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", code: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", code: ErrorKind::Tag })));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::not_line_ending;
+/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
+/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("abc")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("a\rb\nc")), Err(Err::Error((Streaming("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("a\rbc")), Err(Err::Error((Streaming("a\rbc"), ErrorKind::Tag ))));
+/// ```
+#[inline(always)]
+pub fn not_line_ending<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  T: Compare<&'static str>,
+  <T as InputIter>::Item: AsChar,
+  <T as InputIter>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::not_line_ending(input)
+  } else {
+    complete::not_line_ending(input)
+  }
+}
+
+/// Recognizes an end of line (both '\n' and '\r\n').
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::line_ending;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     line_ending(input)
+/// }
+///
+/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::line_ending;
+/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
+/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Err(Err::Error((Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn line_ending<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  T: Compare<&'static str>,
+{
+  if STREAMING {
+    streaming::line_ending(input)
+  } else {
+    complete::line_ending(input)
+  }
+}
+
+/// Matches a newline character '\n'.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::newline;
+/// fn parser(input: &str) -> IResult<&str, char> {
+///     newline(input)
+/// }
+///
+/// assert_eq!(parser("\nc"), Ok(("c", '\n')));
+/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::newline;
+/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
+/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Err(Err::Error((Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn newline<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::newline(input)
+  } else {
+    complete::newline(input)
+  }
+}
+
+/// Matches a tab character '\t'.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::tab;
+/// fn parser(input: &str) -> IResult<&str, char> {
+///     tab(input)
+/// }
+///
+/// assert_eq!(parser("\tc"), Ok(("c", '\t')));
+/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::tab;
+/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
+/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Err(Err::Error((Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn tab<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  <I as InputIter>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::tab(input)
+  } else {
+    complete::tab(input)
+  }
+}
+
+/// Matches one byte as a character. Note that the input type will
+/// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{character::anychar, Err, error::{Error, ErrorKind}, IResult};
+/// fn parser(input: &str) -> IResult<&str, char> {
+///     anychar(input)
+/// }
+///
+/// assert_eq!(parser("abc"), Ok(("bc",'a')));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```
+///
+/// ```
+/// # use nom::{character::anychar, Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// assert_eq!(anychar::<_, (_, ErrorKind), true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
+/// assert_eq!(anychar::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn anychar<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, char, E>
+where
+  T: InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
+  <T as InputIter>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::anychar(input)
+  } else {
+    complete::anychar(input)
+  }
+}
+
+/// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
+///
+/// *Complete version*: Will return the whole input if no terminating token is found (a non
+/// alphabetic character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non alphabetic character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::alpha0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     alpha0(input)
+/// }
+///
+/// assert_eq!(parser("ab1c"), Ok(("1c", "ab")));
+/// assert_eq!(parser("1c"), Ok(("1c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::alpha0;
+/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("ab1c")), Ok((Streaming("1c"), "ab")));
+/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("1c")), Ok((Streaming("1c"), "")));
+/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn alpha0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::alpha0(input)
+  } else {
+    complete::alpha0(input)
+  }
+}
+
+/// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found  (a non alphabetic character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non alphabetic character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::alpha1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     alpha1(input)
+/// }
+///
+/// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
+/// assert_eq!(parser("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Alpha))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::alpha1;
+/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
+/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("1c")), Err(Err::Error((Streaming("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn alpha1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::alpha1(input)
+  } else {
+    complete::alpha1(input)
+  }
+}
+
+/// Recognizes zero or more ASCII numerical characters: 0-9
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::digit0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     digit0(input)
+/// }
+///
+/// assert_eq!(parser("21c"), Ok(("c", "21")));
+/// assert_eq!(parser("21"), Ok(("", "21")));
+/// assert_eq!(parser("a21c"), Ok(("a21c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::digit0;
+/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("21c")), Ok((Streaming("c"), "21")));
+/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("a21c")), Ok((Streaming("a21c"), "")));
+/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn digit0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::digit0(input)
+  } else {
+    complete::digit0(input)
+  }
+}
+
+/// Recognizes one or more ASCII numerical characters: 0-9
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::digit1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     digit1(input)
+/// }
+///
+/// assert_eq!(parser("21c"), Ok(("c", "21")));
+/// assert_eq!(parser("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Digit))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::digit1;
+/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("21c")), Ok((Streaming("c"), "21")));
+/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("c1")), Err(Err::Error((Streaming("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+///
+/// ## Parsing an integer
+///
+/// You can use `digit1` in combination with [`map_res`] to parse an integer:
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::combinator::map_res;
+/// # use nom::character::digit1;
+/// fn parser(input: &str) -> IResult<&str, u32> {
+///   map_res(digit1, str::parse)(input)
+/// }
+///
+/// assert_eq!(parser("416"), Ok(("", 416)));
+/// assert_eq!(parser("12b"), Ok(("b", 12)));
+/// assert!(parser("b").is_err());
+/// ```
+///
+/// [`map_res`]: crate::combinator::map_res
+#[inline(always)]
+pub fn digit1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::digit1(input)
+  } else {
+    complete::digit1(input)
+  }
+}
+
+/// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
+///
+/// *Complete version*: Will return the whole input if no terminating token is found (a non hexadecimal digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non hexadecimal digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::hex_digit0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     hex_digit0(input)
+/// }
+///
+/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::hex_digit0;
+/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn hex_digit0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::hex_digit0(input)
+  } else {
+    complete::hex_digit0(input)
+  }
+}
+
+/// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non hexadecimal digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non hexadecimal digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::hex_digit1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     hex_digit1(input)
+/// }
+///
+/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::HexDigit))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::hex_digit1;
+/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
+/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn hex_digit1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::hex_digit1(input)
+  } else {
+    complete::hex_digit1(input)
+  }
+}
+
+/// Recognizes zero or more octal characters: 0-7
+///
+/// *Complete version*: Will return the whole input if no terminating token is found (a non octal
+/// digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non octal digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::oct_digit0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     oct_digit0(input)
+/// }
+///
+/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::oct_digit0;
+/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn oct_digit0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::oct_digit0(input)
+  } else {
+    complete::oct_digit0(input)
+  }
+}
+
+/// Recognizes one or more octal characters: 0-7
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non octal digit character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non octal digit character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::oct_digit1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     oct_digit1(input)
+/// }
+///
+/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OctDigit))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::oct_digit1;
+/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
+/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn oct_digit1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::oct_digit1(input)
+  } else {
+    complete::oct_digit1(input)
+  }
+}
+
+/// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
+///
+/// *Complete version*: Will return the whole input if no terminating token is found (a non
+/// alphanumerical character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non alphanumerical character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::alphanumeric0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     alphanumeric0(input)
+/// }
+///
+/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(parser("&Z21c"), Ok(("&Z21c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::alphanumeric0;
+/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("&Z21c")), Ok((Streaming("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn alphanumeric0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::alphanumeric0(input)
+  } else {
+    complete::alphanumeric0(input)
+  }
+}
+
+/// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non alphanumerical character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non alphanumerical character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::alphanumeric1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     alphanumeric1(input)
+/// }
+///
+/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(parser("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::alphanumeric1;
+/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
+/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("&H2")), Err(Err::Error((Streaming("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn alphanumeric1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::alphanumeric1(input)
+  } else {
+    complete::alphanumeric1(input)
+  }
+}
+
+/// Recognizes zero or more spaces and tabs.
+///
+/// *Complete version*: Will return the whole input if no terminating token is found (a non space
+/// character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non space character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::space0;
+/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
+/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn space0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+{
+  if STREAMING {
+    streaming::space0(input)
+  } else {
+    complete::space0(input)
+  }
+}
+
+/// Recognizes one or more spaces and tabs.
+///
+/// *Complete version*: Will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non space character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non space character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::space1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     space1(input)
+/// }
+///
+/// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
+/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Space))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::space1;
+/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
+/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn space1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+{
+  if STREAMING {
+    streaming::space1(input)
+  } else {
+    complete::space1(input)
+  }
+}
+
+/// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
+///
+/// *Complete version*: will return the whole input if no terminating token is found (a non space
+/// character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non space character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::character::multispace0;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     multispace0(input)
+/// }
+///
+/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser(""), Ok(("", "")));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::multispace0;
+/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn multispace0<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+{
+  if STREAMING {
+    streaming::multispace0(input)
+  } else {
+    complete::multispace0(input)
+  }
+}
+
+/// Recognizes one or more spaces, tabs, carriage returns and line feeds.
+///
+/// *Complete version*: will return an error if there's not enough input data,
+/// or the whole input if no terminating token is found (a non space character).
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data,
+/// or if no terminating token is found (a non space character).
+///
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use nom::character::multispace1;
+/// fn parser(input: &str) -> IResult<&str, &str> {
+///     multispace1(input)
+/// }
+///
+/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::MultiSpace))));
+/// ```
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// # use nom::character::multispace1;
+/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
+/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn multispace1<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+{
+  if STREAMING {
+    streaming::multispace1(input)
+  } else {
+    complete::multispace1(input)
+  }
+}
+
+#[doc(hidden)]
+macro_rules! ints {
+    ($($t:tt)+) => {
+        $(
+        /// will parse a number in text form to a number
+        ///
+        /// *Complete version*: can parse until the end of input.
+        ///
+        /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+        #[inline(always)]
+        pub fn $t<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, $t, E>
+            where
+            T: InputIter + Slice<RangeFrom<usize>> + InputLength + InputTake + Clone + InputIsStreaming<STREAMING>,
+            T: IntoOutput,
+            <T as InputIter>::Item: AsChar,
+            T: for <'a> Compare<&'a[u8]>,
+            {
+                if STREAMING {
+                  streaming::$t(input)
+                } else {
+                  complete::$t(input)
+                }
+            }
+        )+
+    }
+}
+
+ints! { i8 i16 i32 i64 i128 }
+
+#[doc(hidden)]
+macro_rules! uints {
+    ($($t:tt)+) => {
+        $(
+        /// will parse a number in text form to a number
+        ///
+        /// *Complete version*: can parse until the end of input.
+        ///
+        /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+        #[inline(always)]
+        pub fn $t<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, $t, E>
+            where
+            T: InputIter + Slice<RangeFrom<usize>> + InputLength + InputIsStreaming<STREAMING>,
+            T: IntoOutput,
+            <T as InputIter>::Item: AsChar,
+            {
+                if STREAMING {
+                  streaming::$t(input)
+                } else {
+                  complete::$t(input)
+                }
+            }
+        )+
+    }
+}
+
+uints! { u8 u16 u32 u64 u128 }
 
 #[inline]
 #[doc(hidden)]

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! Functions recognizing specific characters
 
+#![allow(deprecated)] // will just become `pub(crate)` later
+
 pub mod complete;
 pub mod streaming;
 #[cfg(test)]

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -2,6 +2,8 @@
 //!
 //! Functions recognizing specific characters
 
+#![allow(deprecated)]
+
 use crate::branch::alt;
 use crate::combinator::opt;
 use crate::error::ErrorKind;
@@ -29,6 +31,12 @@ use crate::{Err, IResult, Needed};
 /// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::char`][crate::character::char] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::char` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn char<I, Error: ParseError<I>>(c: char) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
@@ -67,6 +75,12 @@ where
 /// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::satisfy`][crate::character::satisfy] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::satisfy` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn satisfy<F, I, Error: ParseError<I>>(cond: F) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -108,6 +122,12 @@ where
 /// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::one_of`][crate::character::one_of] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::one_of` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -142,6 +162,12 @@ where
 /// assert_eq!(none_of::<_, _, (_, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
 /// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::none_of`][crate::character::none_of] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::none_of` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,
@@ -179,6 +205,12 @@ where
 /// assert_eq!(crlf::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(crlf::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(2))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::crlf`][crate::character::crlf] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::crlf` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn crlf<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -211,6 +243,12 @@ where
 /// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rb\nc"), Err(Err::Error(("a\rb\nc", ErrorKind::Tag ))));
 /// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rbc"), Err(Err::Error(("a\rbc", ErrorKind::Tag ))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::not_line_ending`][crate::character::not_line_ending] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::not_line_ending` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -259,6 +297,12 @@ where
 /// assert_eq!(line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::line_ending`][crate::character::line_ending] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::line_ending` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -292,6 +336,12 @@ where
 /// assert_eq!(newline::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
 /// assert_eq!(newline::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::newline`][crate::character::newline] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::newline` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
@@ -312,6 +362,12 @@ where
 /// assert_eq!(tab::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
 /// assert_eq!(tab::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::tab`][crate::character::tab] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::tab` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
@@ -331,6 +387,12 @@ where
 /// assert_eq!(anychar::<_, (_, ErrorKind)>("abc"), Ok(("bc",'a')));
 /// assert_eq!(anychar::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::anychar`][crate::character::anychar] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::anychar` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
   T: InputIter + InputLength + Slice<RangeFrom<usize>>,
@@ -359,6 +421,12 @@ where
 /// assert_eq!(alpha0::<_, (_, ErrorKind)>("1c"), Ok(("1c", "")));
 /// assert_eq!(alpha0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alpha0`][crate::character::alpha0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alpha0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -383,6 +451,12 @@ where
 /// assert_eq!(alpha1::<_, (_, ErrorKind)>("1c"), Err(Err::Error(("1c", ErrorKind::Alpha))));
 /// assert_eq!(alpha1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alpha1`][crate::character::alpha1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alpha1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -407,6 +481,12 @@ where
 /// assert_eq!(digit0::<_, (_, ErrorKind)>("a21c"), Ok(("a21c", "")));
 /// assert_eq!(digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::digit0`][crate::character::digit0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::digit0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -431,6 +511,12 @@ where
 /// assert_eq!(digit1::<_, (_, ErrorKind)>("c1"), Err(Err::Error(("c1", ErrorKind::Digit))));
 /// assert_eq!(digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::digit1`][crate::character::digit1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::digit1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -455,6 +541,12 @@ where
 /// assert_eq!(hex_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(hex_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::hex_digit0`][crate::character::hex_digit0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::hex_digit0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -479,6 +571,12 @@ where
 /// assert_eq!(hex_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::HexDigit))));
 /// assert_eq!(hex_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::hex_digit1`][crate::character::hex_digit1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::hex_digit1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -503,6 +601,12 @@ where
 /// assert_eq!(oct_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(oct_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::oct_digit0`][crate::character::oct_digit0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::oct_digit0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -527,6 +631,12 @@ where
 /// assert_eq!(oct_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::OctDigit))));
 /// assert_eq!(oct_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::oct_digit1`][crate::character::oct_digit1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::oct_digit1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -551,6 +661,12 @@ where
 /// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>("&Z21c"), Ok(("&Z21c", "")));
 /// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alphanumeric0`][crate::character::alphanumeric0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alphanumeric0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -575,6 +691,12 @@ where
 /// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>("&H2"), Err(Err::Error(("&H2", ErrorKind::AlphaNumeric))));
 /// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::alphanumeric1`][crate::character::alphanumeric1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::alphanumeric1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -599,6 +721,12 @@ where
 /// assert_eq!(space0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(space0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::space0`][crate::character::space0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::space0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -625,6 +753,12 @@ where
 /// assert_eq!(space1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::Space))));
 /// assert_eq!(space1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::space1`][crate::character::space1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::space1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -655,6 +789,12 @@ where
 /// assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
 /// assert_eq!(multispace0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::multispace0`][crate::character::multispace0] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::multispace0` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,
@@ -682,6 +822,12 @@ where
 /// assert_eq!(multispace1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::MultiSpace))));
 /// assert_eq!(multispace1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::character::multispace1`][crate::character::multispace1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::character::multispace1` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: InputTakeAtPosition,

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -34,7 +34,15 @@ where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: AsChar,
 {
-  move |i: I| match (i).iter_elements().next().map(|t| {
+  move |i: I| char_internal(i, c)
+}
+
+pub(crate) fn char_internal<I, Error: ParseError<I>>(i: I, c: char) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  <I as InputIter>::Item: AsChar,
+{
+  match (i).iter_elements().next().map(|t| {
     let b = t.as_char() == c;
     (&c, b)
   }) {
@@ -65,7 +73,19 @@ where
   <I as InputIter>::Item: AsChar,
   F: Fn(char) -> bool,
 {
-  move |i: I| match (i).iter_elements().next().map(|t| {
+  move |i: I| satisfy_internal(i, &cond)
+}
+
+pub(crate) fn satisfy_internal<F, I, Error: ParseError<I>>(
+  i: I,
+  cond: &F,
+) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter,
+  <I as InputIter>::Item: AsChar,
+  F: Fn(char) -> bool,
+{
+  match (i).iter_elements().next().map(|t| {
     let c = t.as_char();
     let b = cond(c);
     (c, b)
@@ -94,7 +114,16 @@ where
   <I as InputIter>::Item: AsChar + Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  move |i: I| match (i).iter_elements().next().map(|c| (c, list.find_token(c))) {
+  move |i: I| one_of_internal(i, &list)
+}
+
+pub(crate) fn one_of_internal<I, T, Error: ParseError<I>>(i: I, list: &T) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter,
+  <I as InputIter>::Item: AsChar + Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  match (i).iter_elements().next().map(|c| (c, list.find_token(c))) {
     None => Err(Err::Incomplete(Needed::new(1))),
     Some((_, false)) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::OneOf))),
     Some((c, true)) => Ok((i.slice(c.len()..), c.as_char())),
@@ -119,7 +148,19 @@ where
   <I as InputIter>::Item: AsChar + Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  move |i: I| match (i).iter_elements().next().map(|c| (c, !list.find_token(c))) {
+  move |i: I| none_of_internal(i, &list)
+}
+
+pub(crate) fn none_of_internal<I, T, Error: ParseError<I>>(
+  i: I,
+  list: &T,
+) -> IResult<I, char, Error>
+where
+  I: Slice<RangeFrom<usize>> + InputIter,
+  <I as InputIter>::Item: AsChar + Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  match (i).iter_elements().next().map(|c| (c, !list.find_token(c))) {
     None => Err(Err::Incomplete(Needed::new(1))),
     Some((_, false)) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::NoneOf))),
     Some((c, true)) => Ok((i.slice(c.len()..), c.as_char())),

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -1,0 +1,1061 @@
+use super::*;
+
+mod complete {
+  use super::*;
+  use crate::branch::alt;
+  use crate::combinator::opt;
+  use crate::error::ErrorKind;
+  use crate::input::ParseTo;
+  use crate::Err;
+  use proptest::prelude::*;
+  macro_rules! assert_parse(
+    ($left: expr, $right: expr) => {
+      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      assert_eq!(res, $right);
+    };
+  );
+
+  #[test]
+  fn character() {
+    let empty: &[u8] = b"";
+    let a: &[u8] = b"abcd";
+    let b: &[u8] = b"1234";
+    let c: &[u8] = b"a123";
+    let d: &[u8] = "azé12".as_bytes();
+    let e: &[u8] = b" ";
+    let f: &[u8] = b" ;";
+    //assert_eq!(alpha1::<_, (_, ErrorKind)>(a), Err(Err::Incomplete(Needed::Size(1))));
+    assert_parse!(alpha1(a), Ok((empty, a)));
+    assert_eq!(alpha1(b), Err(Err::Error((b, ErrorKind::Alpha))));
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), false>(c),
+      Ok((&c[1..], &b"a"[..]))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), false>(d),
+      Ok(("é12".as_bytes(), &b"az"[..]))
+    );
+    assert_eq!(digit1(a), Err(Err::Error((a, ErrorKind::Digit))));
+    assert_eq!(digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(digit1(c), Err(Err::Error((c, ErrorKind::Digit))));
+    assert_eq!(digit1(d), Err(Err::Error((d, ErrorKind::Digit))));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(a), Ok((empty, a)));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(c), Ok((empty, c)));
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), false>(d),
+      Ok(("zé12".as_bytes(), &b"a"[..]))
+    );
+    assert_eq!(hex_digit1(e), Err(Err::Error((e, ErrorKind::HexDigit))));
+    assert_eq!(oct_digit1(a), Err(Err::Error((a, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(oct_digit1(c), Err(Err::Error((c, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit1(d), Err(Err::Error((d, ErrorKind::OctDigit))));
+    assert_eq!(alphanumeric1::<_, (_, ErrorKind), false>(a), Ok((empty, a)));
+    //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
+    assert_eq!(alphanumeric1::<_, (_, ErrorKind), false>(c), Ok((empty, c)));
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), false>(d),
+      Ok(("é12".as_bytes(), &b"az"[..]))
+    );
+    assert_eq!(space1::<_, (_, ErrorKind), false>(e), Ok((empty, e)));
+    assert_eq!(
+      space1::<_, (_, ErrorKind), false>(f),
+      Ok((&b";"[..], &b" "[..]))
+    );
+  }
+
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn character_s() {
+    let empty = "";
+    let a = "abcd";
+    let b = "1234";
+    let c = "a123";
+    let d = "azé12";
+    let e = " ";
+    assert_eq!(alpha1::<_, (_, ErrorKind), false>(a), Ok((empty, a)));
+    assert_eq!(alpha1(b), Err(Err::Error((b, ErrorKind::Alpha))));
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), false>(c),
+      Ok((&c[1..], &"a"[..]))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), false>(d),
+      Ok(("é12", &"az"[..]))
+    );
+    assert_eq!(digit1(a), Err(Err::Error((a, ErrorKind::Digit))));
+    assert_eq!(digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(digit1(c), Err(Err::Error((c, ErrorKind::Digit))));
+    assert_eq!(digit1(d), Err(Err::Error((d, ErrorKind::Digit))));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(a), Ok((empty, a)));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(hex_digit1::<_, (_, ErrorKind), false>(c), Ok((empty, c)));
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), false>(d),
+      Ok(("zé12", &"a"[..]))
+    );
+    assert_eq!(hex_digit1(e), Err(Err::Error((e, ErrorKind::HexDigit))));
+    assert_eq!(oct_digit1(a), Err(Err::Error((a, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit1::<_, (_, ErrorKind), false>(b), Ok((empty, b)));
+    assert_eq!(oct_digit1(c), Err(Err::Error((c, ErrorKind::OctDigit))));
+    assert_eq!(oct_digit1(d), Err(Err::Error((d, ErrorKind::OctDigit))));
+    assert_eq!(alphanumeric1::<_, (_, ErrorKind), false>(a), Ok((empty, a)));
+    //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
+    assert_eq!(alphanumeric1::<_, (_, ErrorKind), false>(c), Ok((empty, c)));
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), false>(d),
+      Ok(("é12", "az"))
+    );
+    assert_eq!(space1::<_, (_, ErrorKind), false>(e), Ok((empty, e)));
+  }
+
+  use crate::input::Offset;
+  #[test]
+  fn offset() {
+    let a = &b"abcd;"[..];
+    let b = &b"1234;"[..];
+    let c = &b"a123;"[..];
+    let d = &b" \t;"[..];
+    let e = &b" \t\r\n;"[..];
+    let f = &b"123abcDEF;"[..];
+
+    match alpha1::<_, (_, ErrorKind), false>(a) {
+      Ok((i, _)) => {
+        assert_eq!(a.offset(i) + i.len(), a.len());
+      }
+      _ => panic!("wrong return type in offset test for alpha"),
+    }
+    match digit1::<_, (_, ErrorKind), false>(b) {
+      Ok((i, _)) => {
+        assert_eq!(b.offset(i) + i.len(), b.len());
+      }
+      _ => panic!("wrong return type in offset test for digit"),
+    }
+    match alphanumeric1::<_, (_, ErrorKind), false>(c) {
+      Ok((i, _)) => {
+        assert_eq!(c.offset(i) + i.len(), c.len());
+      }
+      _ => panic!("wrong return type in offset test for alphanumeric"),
+    }
+    match space1::<_, (_, ErrorKind), false>(d) {
+      Ok((i, _)) => {
+        assert_eq!(d.offset(i) + i.len(), d.len());
+      }
+      _ => panic!("wrong return type in offset test for space"),
+    }
+    match multispace1::<_, (_, ErrorKind), false>(e) {
+      Ok((i, _)) => {
+        assert_eq!(e.offset(i) + i.len(), e.len());
+      }
+      _ => panic!("wrong return type in offset test for multispace"),
+    }
+    match hex_digit1::<_, (_, ErrorKind), false>(f) {
+      Ok((i, _)) => {
+        assert_eq!(f.offset(i) + i.len(), f.len());
+      }
+      _ => panic!("wrong return type in offset test for hex_digit"),
+    }
+    match oct_digit1::<_, (_, ErrorKind), false>(f) {
+      Ok((i, _)) => {
+        assert_eq!(f.offset(i) + i.len(), f.len());
+      }
+      _ => panic!("wrong return type in offset test for oct_digit"),
+    }
+  }
+
+  #[test]
+  fn is_not_line_ending_bytes() {
+    let a: &[u8] = b"ab12cd\nefgh";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), false>(a),
+      Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
+    );
+
+    let b: &[u8] = b"ab12cd\nefgh\nijkl";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), false>(b),
+      Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
+    );
+
+    let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), false>(c),
+      Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
+    );
+
+    let d: &[u8] = b"ab12cd";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), false>(d),
+      Ok((&[][..], &d[..]))
+    );
+  }
+
+  #[test]
+  fn is_not_line_ending_str() {
+    /*
+    let a: &str = "ab12cd\nefgh";
+    assert_eq!(not_line_ending(a), Ok((&"\nefgh"[..], &"ab12cd"[..])));
+
+    let b: &str = "ab12cd\nefgh\nijkl";
+    assert_eq!(not_line_ending(b), Ok((&"\nefgh\nijkl"[..], &"ab12cd"[..])));
+
+    let c: &str = "ab12cd\r\nefgh\nijkl";
+    assert_eq!(not_line_ending(c), Ok((&"\r\nefgh\nijkl"[..], &"ab12cd"[..])));
+
+    let d = "βèƒôřè\nÂßÇáƒƭèř";
+    assert_eq!(not_line_ending(d), Ok((&"\nÂßÇáƒƭèř"[..], &"βèƒôřè"[..])));
+
+    let e = "βèƒôřè\r\nÂßÇáƒƭèř";
+    assert_eq!(not_line_ending(e), Ok((&"\r\nÂßÇáƒƭèř"[..], &"βèƒôřè"[..])));
+    */
+
+    let f = "βèƒôřè\rÂßÇáƒƭèř";
+    assert_eq!(not_line_ending(f), Err(Err::Error((f, ErrorKind::Tag))));
+
+    let g2: &str = "ab12cd";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), false>(g2),
+      Ok(("", g2))
+    );
+  }
+
+  #[test]
+  fn hex_digit_test() {
+    let i = &b"0123456789abcdefABCDEF;"[..];
+    assert_parse!(hex_digit1(i), Ok((&b";"[..], &i[..i.len() - 1])));
+
+    let i = &b"g"[..];
+    assert_parse!(
+      hex_digit1(i),
+      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+    );
+
+    let i = &b"G"[..];
+    assert_parse!(
+      hex_digit1(i),
+      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+    );
+
+    assert!(AsChar::is_hex_digit(b'0'));
+    assert!(AsChar::is_hex_digit(b'9'));
+    assert!(AsChar::is_hex_digit(b'a'));
+    assert!(AsChar::is_hex_digit(b'f'));
+    assert!(AsChar::is_hex_digit(b'A'));
+    assert!(AsChar::is_hex_digit(b'F'));
+    assert!(!AsChar::is_hex_digit(b'g'));
+    assert!(!AsChar::is_hex_digit(b'G'));
+    assert!(!AsChar::is_hex_digit(b'/'));
+    assert!(!AsChar::is_hex_digit(b':'));
+    assert!(!AsChar::is_hex_digit(b'@'));
+    assert!(!AsChar::is_hex_digit(b'\x60'));
+  }
+
+  #[test]
+  fn oct_digit_test() {
+    let i = &b"01234567;"[..];
+    assert_parse!(oct_digit1(i), Ok((&b";"[..], &i[..i.len() - 1])));
+
+    let i = &b"8"[..];
+    assert_parse!(
+      oct_digit1(i),
+      Err(Err::Error(error_position!(i, ErrorKind::OctDigit)))
+    );
+
+    assert!(AsChar::is_oct_digit(b'0'));
+    assert!(AsChar::is_oct_digit(b'7'));
+    assert!(!AsChar::is_oct_digit(b'8'));
+    assert!(!AsChar::is_oct_digit(b'9'));
+    assert!(!AsChar::is_oct_digit(b'a'));
+    assert!(!AsChar::is_oct_digit(b'A'));
+    assert!(!AsChar::is_oct_digit(b'/'));
+    assert!(!AsChar::is_oct_digit(b':'));
+    assert!(!AsChar::is_oct_digit(b'@'));
+    assert!(!AsChar::is_oct_digit(b'\x60'));
+  }
+
+  #[test]
+  fn full_line_windows() {
+    use crate::sequence::pair;
+    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+      pair(not_line_ending, line_ending)(i)
+    }
+    let input = b"abc\r\n";
+    let output = take_full_line(input);
+    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\r\n"[..]))));
+  }
+
+  #[test]
+  fn full_line_unix() {
+    use crate::sequence::pair;
+    fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+      pair(not_line_ending, line_ending)(i)
+    }
+    let input = b"abc\n";
+    let output = take_full_line(input);
+    assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\n"[..]))));
+  }
+
+  #[test]
+  fn check_windows_lineending() {
+    let input = b"\r\n";
+    let output = line_ending(&input[..]);
+    assert_parse!(output, Ok((&b""[..], &b"\r\n"[..])));
+  }
+
+  #[test]
+  fn check_unix_lineending() {
+    let input = b"\n";
+    let output = line_ending(&input[..]);
+    assert_parse!(output, Ok((&b""[..], &b"\n"[..])));
+  }
+
+  #[test]
+  fn cr_lf() {
+    assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
+    assert_parse!(
+      crlf(&b"\r"[..]),
+      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+    );
+    assert_parse!(
+      crlf(&b"\ra"[..]),
+      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+    );
+
+    assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
+    assert_parse!(
+      crlf("\r"),
+      Err(Err::Error(error_position!(&"\r"[..], ErrorKind::CrLf)))
+    );
+    assert_parse!(
+      crlf("\ra"),
+      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+    );
+  }
+
+  #[test]
+  fn end_of_line() {
+    assert_parse!(line_ending(&b"\na"[..]), Ok((&b"a"[..], &b"\n"[..])));
+    assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
+    assert_parse!(
+      line_ending(&b"\r"[..]),
+      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+    );
+    assert_parse!(
+      line_ending(&b"\ra"[..]),
+      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+    );
+
+    assert_parse!(line_ending("\na"), Ok(("a", "\n")));
+    assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
+    assert_parse!(
+      line_ending("\r"),
+      Err(Err::Error(error_position!(&"\r"[..], ErrorKind::CrLf)))
+    );
+    assert_parse!(
+      line_ending("\ra"),
+      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+    );
+  }
+
+  fn digit_to_i16(input: &str) -> IResult<&str, i16> {
+    let i = input;
+    let (i, opt_sign) = opt(alt((char('+'), char('-'))))(i)?;
+    let sign = match opt_sign {
+      Some('+') => true,
+      Some('-') => false,
+      _ => true,
+    };
+
+    let (i, s) = match digit1::<_, crate::error::Error<_>, false>(i) {
+      Ok((i, s)) => (i, s),
+      Err(_) => {
+        return Err(Err::Error(crate::error::Error::from_error_kind(
+          input,
+          ErrorKind::Digit,
+        )))
+      }
+    };
+
+    match s.parse_to() {
+      Some(n) => {
+        if sign {
+          Ok((i, n))
+        } else {
+          Ok((i, -n))
+        }
+      }
+      None => Err(Err::Error(crate::error::Error::from_error_kind(
+        i,
+        ErrorKind::Digit,
+      ))),
+    }
+  }
+
+  fn digit_to_u32(i: &str) -> IResult<&str, u32> {
+    let (i, s) = digit1(i)?;
+    match s.parse_to() {
+      Some(n) => Ok((i, n)),
+      None => Err(Err::Error(crate::error::Error::from_error_kind(
+        i,
+        ErrorKind::Digit,
+      ))),
+    }
+  }
+
+  proptest! {
+    #[test]
+    fn ints(s in "\\PC*") {
+        let res1 = digit_to_i16(&s);
+        let res2 = i16(s.as_str());
+        assert_eq!(res1, res2);
+    }
+
+    #[test]
+    fn uints(s in "\\PC*") {
+        let res1 = digit_to_u32(&s);
+        let res2 = u32(s.as_str());
+        assert_eq!(res1, res2);
+    }
+  }
+}
+
+mod streaming {
+  use super::*;
+  use crate::branch::alt;
+  use crate::combinator::opt;
+  use crate::error::ErrorKind;
+  use crate::input::ParseTo;
+  use crate::input::Streaming;
+  use crate::sequence::pair;
+  use crate::{Err, IResult, Needed};
+  use proptest::prelude::*;
+
+  macro_rules! assert_parse(
+    ($left: expr, $right: expr) => {
+      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      assert_eq!(res, $right);
+    };
+  );
+
+  #[test]
+  fn anychar_str() {
+    use super::anychar;
+    assert_eq!(
+      anychar::<_, (Streaming<&str>, ErrorKind), true>(Streaming("Ә")),
+      Ok((Streaming(""), 'Ә'))
+    );
+  }
+
+  #[test]
+  fn character() {
+    let a: &[u8] = b"abcd";
+    let b: &[u8] = b"1234";
+    let c: &[u8] = b"a123";
+    let d: &[u8] = "azé12".as_bytes();
+    let e: &[u8] = b" ";
+    let f: &[u8] = b" ;";
+    //assert_eq!(alpha1::<_, (_, ErrorKind), true>(a), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(alpha1(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      alpha1(Streaming(b)),
+      Err(Err::Error((Streaming(b), ErrorKind::Alpha)))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Ok((Streaming(&c[1..]), &b"a"[..]))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("é12".as_bytes()), &b"az"[..]))
+    );
+    assert_eq!(
+      digit1(Streaming(a)),
+      Err(Err::Error((Streaming(a), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      digit1(Streaming(c)),
+      Err(Err::Error((Streaming(c), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(Streaming(d)),
+      Err(Err::Error((Streaming(d), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(a)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("zé12".as_bytes()), &b"a"[..]))
+    );
+    assert_eq!(
+      hex_digit1(Streaming(e)),
+      Err(Err::Error((Streaming(e), ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(a)),
+      Err(Err::Error((Streaming(a), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(c)),
+      Err(Err::Error((Streaming(c), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(d)),
+      Err(Err::Error((Streaming(d), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(a)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("é12".as_bytes()), &b"az"[..]))
+    );
+    assert_eq!(
+      space1::<_, (_, ErrorKind), true>(Streaming(e)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      space1::<_, (_, ErrorKind), true>(Streaming(f)),
+      Ok((Streaming(&b";"[..]), &b" "[..]))
+    );
+  }
+
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn character_s() {
+    let a = "abcd";
+    let b = "1234";
+    let c = "a123";
+    let d = "azé12";
+    let e = " ";
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), true>(Streaming(a)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      alpha1(Streaming(b)),
+      Err(Err::Error((Streaming(b), ErrorKind::Alpha)))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Ok((Streaming(&c[1..]), &"a"[..]))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("é12"), &"az"[..]))
+    );
+    assert_eq!(
+      digit1(Streaming(a)),
+      Err(Err::Error((Streaming(a), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      digit1(Streaming(c)),
+      Err(Err::Error((Streaming(c), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(Streaming(d)),
+      Err(Err::Error((Streaming(d), ErrorKind::Digit)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(a)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("zé12"), &"a"[..]))
+    );
+    assert_eq!(
+      hex_digit1(Streaming(e)),
+      Err(Err::Error((Streaming(e), ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(a)),
+      Err(Err::Error((Streaming(a), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1::<_, (_, ErrorKind), true>(Streaming(b)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(c)),
+      Err(Err::Error((Streaming(c), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1(Streaming(d)),
+      Err(Err::Error((Streaming(d), ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(a)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(c)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind), true>(Streaming(d)),
+      Ok((Streaming("é12"), "az"))
+    );
+    assert_eq!(
+      space1::<_, (_, ErrorKind), true>(Streaming(e)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  use crate::input::Offset;
+  #[test]
+  fn offset() {
+    let a = &b"abcd;"[..];
+    let b = &b"1234;"[..];
+    let c = &b"a123;"[..];
+    let d = &b" \t;"[..];
+    let e = &b" \t\r\n;"[..];
+    let f = &b"123abcDEF;"[..];
+
+    match alpha1::<_, (_, ErrorKind), true>(Streaming(a)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(a.offset(i) + i.len(), a.len());
+      }
+      _ => panic!("wrong return type in offset test for alpha"),
+    }
+    match digit1::<_, (_, ErrorKind), true>(Streaming(b)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(b.offset(i) + i.len(), b.len());
+      }
+      _ => panic!("wrong return type in offset test for digit"),
+    }
+    match alphanumeric1::<_, (_, ErrorKind), true>(Streaming(c)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(c.offset(i) + i.len(), c.len());
+      }
+      _ => panic!("wrong return type in offset test for alphanumeric"),
+    }
+    match space1::<_, (_, ErrorKind), true>(Streaming(d)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(d.offset(i) + i.len(), d.len());
+      }
+      _ => panic!("wrong return type in offset test for space"),
+    }
+    match multispace1::<_, (_, ErrorKind), true>(Streaming(e)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(e.offset(i) + i.len(), e.len());
+      }
+      _ => panic!("wrong return type in offset test for multispace"),
+    }
+    match hex_digit1::<_, (_, ErrorKind), true>(Streaming(f)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(f.offset(i) + i.len(), f.len());
+      }
+      _ => panic!("wrong return type in offset test for hex_digit"),
+    }
+    match oct_digit1::<_, (_, ErrorKind), true>(Streaming(f)) {
+      Ok((Streaming(i), _)) => {
+        assert_eq!(f.offset(i) + i.len(), f.len());
+      }
+      _ => panic!("wrong return type in offset test for oct_digit"),
+    }
+  }
+
+  #[test]
+  fn is_not_line_ending_bytes() {
+    let a: &[u8] = b"ab12cd\nefgh";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), true>(Streaming(a)),
+      Ok((Streaming(&b"\nefgh"[..]), &b"ab12cd"[..]))
+    );
+
+    let b: &[u8] = b"ab12cd\nefgh\nijkl";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), true>(Streaming(b)),
+      Ok((Streaming(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+    );
+
+    let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), true>(Streaming(c)),
+      Ok((Streaming(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+    );
+
+    let d: &[u8] = b"ab12cd";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), true>(Streaming(d)),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+  }
+
+  #[test]
+  fn is_not_line_ending_str() {
+    /*
+    let a: &str = "ab12cd\nefgh";
+    assert_eq!(not_line_ending(a), Ok((&"\nefgh"[..], &"ab12cd"[..])));
+
+    let b: &str = "ab12cd\nefgh\nijkl";
+    assert_eq!(not_line_ending(b), Ok((&"\nefgh\nijkl"[..], &"ab12cd"[..])));
+
+    let c: &str = "ab12cd\r\nefgh\nijkl";
+    assert_eq!(not_line_ending(c), Ok((&"\r\nefgh\nijkl"[..], &"ab12cd"[..])));
+
+    let d = "βèƒôřè\nÂßÇáƒƭèř";
+    assert_eq!(not_line_ending(d), Ok((&"\nÂßÇáƒƭèř"[..], &"βèƒôřè"[..])));
+
+    let e = "βèƒôřè\r\nÂßÇáƒƭèř";
+    assert_eq!(not_line_ending(e), Ok((&"\r\nÂßÇáƒƭèř"[..], &"βèƒôřè"[..])));
+    */
+
+    let f = "βèƒôřè\rÂßÇáƒƭèř";
+    assert_eq!(
+      not_line_ending(Streaming(f)),
+      Err(Err::Error((Streaming(f), ErrorKind::Tag)))
+    );
+
+    let g2: &str = "ab12cd";
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind), true>(Streaming(g2)),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+  }
+
+  #[test]
+  fn hex_digit_test() {
+    let i = &b"0123456789abcdefABCDEF;"[..];
+    assert_parse!(
+      hex_digit1(Streaming(i)),
+      Ok((Streaming(&b";"[..]), &i[..i.len() - 1]))
+    );
+
+    let i = &b"g"[..];
+    assert_parse!(
+      hex_digit1(Streaming(i)),
+      Err(Err::Error(error_position!(
+        Streaming(i),
+        ErrorKind::HexDigit
+      )))
+    );
+
+    let i = &b"G"[..];
+    assert_parse!(
+      hex_digit1(Streaming(i)),
+      Err(Err::Error(error_position!(
+        Streaming(i),
+        ErrorKind::HexDigit
+      )))
+    );
+
+    assert!(AsChar::is_hex_digit(b'0'));
+    assert!(AsChar::is_hex_digit(b'9'));
+    assert!(AsChar::is_hex_digit(b'a'));
+    assert!(AsChar::is_hex_digit(b'f'));
+    assert!(AsChar::is_hex_digit(b'A'));
+    assert!(AsChar::is_hex_digit(b'F'));
+    assert!(!AsChar::is_hex_digit(b'g'));
+    assert!(!AsChar::is_hex_digit(b'G'));
+    assert!(!AsChar::is_hex_digit(b'/'));
+    assert!(!AsChar::is_hex_digit(b':'));
+    assert!(!AsChar::is_hex_digit(b'@'));
+    assert!(!AsChar::is_hex_digit(b'\x60'));
+  }
+
+  #[test]
+  fn oct_digit_test() {
+    let i = &b"01234567;"[..];
+    assert_parse!(
+      oct_digit1(Streaming(i)),
+      Ok((Streaming(&b";"[..]), &i[..i.len() - 1]))
+    );
+
+    let i = &b"8"[..];
+    assert_parse!(
+      oct_digit1(Streaming(i)),
+      Err(Err::Error(error_position!(
+        Streaming(i),
+        ErrorKind::OctDigit
+      )))
+    );
+
+    assert!(AsChar::is_oct_digit(b'0'));
+    assert!(AsChar::is_oct_digit(b'7'));
+    assert!(!AsChar::is_oct_digit(b'8'));
+    assert!(!AsChar::is_oct_digit(b'9'));
+    assert!(!AsChar::is_oct_digit(b'a'));
+    assert!(!AsChar::is_oct_digit(b'A'));
+    assert!(!AsChar::is_oct_digit(b'/'));
+    assert!(!AsChar::is_oct_digit(b':'));
+    assert!(!AsChar::is_oct_digit(b'@'));
+    assert!(!AsChar::is_oct_digit(b'\x60'));
+  }
+
+  #[test]
+  fn full_line_windows() {
+    fn take_full_line(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
+      pair(not_line_ending, line_ending)(i)
+    }
+    let input = b"abc\r\n";
+    let output = take_full_line(Streaming(input));
+    assert_eq!(
+      output,
+      Ok((Streaming(&b""[..]), (&b"abc"[..], &b"\r\n"[..])))
+    );
+  }
+
+  #[test]
+  fn full_line_unix() {
+    fn take_full_line(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
+      pair(not_line_ending, line_ending)(i)
+    }
+    let input = b"abc\n";
+    let output = take_full_line(Streaming(input));
+    assert_eq!(output, Ok((Streaming(&b""[..]), (&b"abc"[..], &b"\n"[..]))));
+  }
+
+  #[test]
+  fn check_windows_lineending() {
+    let input = b"\r\n";
+    let output = line_ending(Streaming(&input[..]));
+    assert_parse!(output, Ok((Streaming(&b""[..]), &b"\r\n"[..])));
+  }
+
+  #[test]
+  fn check_unix_lineending() {
+    let input = b"\n";
+    let output = line_ending(Streaming(&input[..]));
+    assert_parse!(output, Ok((Streaming(&b""[..]), &b"\n"[..])));
+  }
+
+  #[test]
+  fn cr_lf() {
+    assert_parse!(
+      crlf(Streaming(&b"\r\na"[..])),
+      Ok((Streaming(&b"a"[..]), &b"\r\n"[..]))
+    );
+    assert_parse!(
+      crlf(Streaming(&b"\r"[..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      crlf(Streaming(&b"\ra"[..])),
+      Err(Err::Error(error_position!(
+        Streaming(&b"\ra"[..]),
+        ErrorKind::CrLf
+      )))
+    );
+
+    assert_parse!(crlf(Streaming("\r\na")), Ok((Streaming("a"), "\r\n")));
+    assert_parse!(crlf(Streaming("\r")), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(
+      crlf(Streaming("\ra")),
+      Err(Err::Error(error_position!(
+        Streaming("\ra"),
+        ErrorKind::CrLf
+      )))
+    );
+  }
+
+  #[test]
+  fn end_of_line() {
+    assert_parse!(
+      line_ending(Streaming(&b"\na"[..])),
+      Ok((Streaming(&b"a"[..]), &b"\n"[..]))
+    );
+    assert_parse!(
+      line_ending(Streaming(&b"\r\na"[..])),
+      Ok((Streaming(&b"a"[..]), &b"\r\n"[..]))
+    );
+    assert_parse!(
+      line_ending(Streaming(&b"\r"[..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      line_ending(Streaming(&b"\ra"[..])),
+      Err(Err::Error(error_position!(
+        Streaming(&b"\ra"[..]),
+        ErrorKind::CrLf
+      )))
+    );
+
+    assert_parse!(line_ending(Streaming("\na")), Ok((Streaming("a"), "\n")));
+    assert_parse!(
+      line_ending(Streaming("\r\na")),
+      Ok((Streaming("a"), "\r\n"))
+    );
+    assert_parse!(
+      line_ending(Streaming("\r")),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      line_ending(Streaming("\ra")),
+      Err(Err::Error(error_position!(
+        Streaming("\ra"),
+        ErrorKind::CrLf
+      )))
+    );
+  }
+
+  fn digit_to_i16(input: Streaming<&str>) -> IResult<Streaming<&str>, i16> {
+    let i = input;
+    let (i, opt_sign) = opt(alt((char('+'), char('-'))))(i)?;
+    let sign = match opt_sign {
+      Some('+') => true,
+      Some('-') => false,
+      _ => true,
+    };
+
+    let (i, s) = match digit1::<_, crate::error::Error<_>, true>(i) {
+      Ok((i, s)) => (i, s),
+      Err(Err::Incomplete(i)) => return Err(Err::Incomplete(i)),
+      Err(_) => {
+        return Err(Err::Error(crate::error::Error::from_error_kind(
+          input,
+          ErrorKind::Digit,
+        )))
+      }
+    };
+    match s.parse_to() {
+      Some(n) => {
+        if sign {
+          Ok((i, n))
+        } else {
+          Ok((i, -n))
+        }
+      }
+      None => Err(Err::Error(crate::error::Error::from_error_kind(
+        i,
+        ErrorKind::Digit,
+      ))),
+    }
+  }
+
+  fn digit_to_u32(i: Streaming<&str>) -> IResult<Streaming<&str>, u32> {
+    let (i, s) = digit1(i)?;
+    match s.parse_to() {
+      Some(n) => Ok((i, n)),
+      None => Err(Err::Error(crate::error::Error::from_error_kind(
+        i,
+        ErrorKind::Digit,
+      ))),
+    }
+  }
+
+  #[test]
+  fn one_of_test() {
+    fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
+      one_of("ab")(i)
+    }
+
+    let a = &b"abcd"[..];
+    assert_eq!(f(Streaming(a)), Ok((Streaming(&b"bcd"[..]), 'a')));
+
+    let b = &b"cde"[..];
+    assert_eq!(
+      f(Streaming(b)),
+      Err(Err::Error(error_position!(Streaming(b), ErrorKind::OneOf)))
+    );
+
+    fn utf8(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+      one_of("+\u{FF0B}")(i)
+    }
+
+    assert!(utf8(Streaming("+")).is_ok());
+    assert!(utf8(Streaming("\u{FF0B}")).is_ok());
+  }
+
+  #[test]
+  fn none_of_test() {
+    fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
+      none_of("ab")(i)
+    }
+
+    let a = &b"abcd"[..];
+    assert_eq!(
+      f(Streaming(a)),
+      Err(Err::Error(error_position!(Streaming(a), ErrorKind::NoneOf)))
+    );
+
+    let b = &b"cde"[..];
+    assert_eq!(f(Streaming(b)), Ok((Streaming(&b"de"[..]), 'c')));
+  }
+
+  #[test]
+  fn char_byteslice() {
+    fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
+      char('c')(i)
+    }
+
+    let a = &b"abcd"[..];
+    assert_eq!(
+      f(Streaming(a)),
+      Err(Err::Error(error_position!(Streaming(a), ErrorKind::Char)))
+    );
+
+    let b = &b"cde"[..];
+    assert_eq!(f(Streaming(b)), Ok((Streaming(&b"de"[..]), 'c')));
+  }
+
+  #[test]
+  fn char_str() {
+    fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+      char('c')(i)
+    }
+
+    let a = &"abcd"[..];
+    assert_eq!(
+      f(Streaming(a)),
+      Err(Err::Error(error_position!(Streaming(a), ErrorKind::Char)))
+    );
+
+    let b = &"cde"[..];
+    assert_eq!(f(Streaming(b)), Ok((Streaming(&"de"[..]), 'c')));
+  }
+
+  proptest! {
+    #[test]
+    fn ints(s in "\\PC*") {
+        let res1 = digit_to_i16(Streaming(&s));
+        let res2 = i16(Streaming(s.as_str()));
+        assert_eq!(res1, res2);
+    }
+
+    #[test]
+    fn uints(s in "\\PC*") {
+        let res1 = digit_to_u32(Streaming(&s));
+        let res2 = u32(Streaming(s.as_str()));
+        assert_eq!(res1, res2);
+    }
+  }
+}

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -205,7 +205,7 @@ where
 ///
 /// ```rust
 /// use nom::{Err,error::ErrorKind, IResult,Parser};
-/// use nom::character::complete::digit1;
+/// use nom::character::digit1;
 /// use nom::combinator::map;
 /// # fn main() {
 ///
@@ -278,7 +278,7 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> fo
 ///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
-/// use nom::character::complete::digit1;
+/// use nom::character::digit1;
 /// use nom::combinator::map_res;
 /// # fn main() {
 ///
@@ -316,7 +316,7 @@ where
 ///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
-/// use nom::character::complete::digit1;
+/// use nom::character::digit1;
 /// use nom::combinator::map_opt;
 /// # fn main() {
 ///
@@ -354,8 +354,8 @@ where
 ///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
-/// use nom::character::complete::digit1;
-/// use nom::bytes::complete::take;
+/// use nom::character::digit1;
+/// use nom::bytes::take;
 /// use nom::combinator::map_parser;
 /// # fn main() {
 ///
@@ -385,8 +385,8 @@ where
 ///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
-/// use nom::bytes::complete::take;
-/// use nom::number::complete::u8;
+/// use nom::bytes::take;
+/// use nom::number::u8;
 /// use nom::combinator::flat_map;
 /// # fn main() {
 ///
@@ -443,7 +443,7 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>>
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::opt;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// fn parser(i: &str) -> IResult<&str, Option<&str>> {
@@ -551,7 +551,7 @@ impl<'a, I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Par
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, IResult};
 /// use nom::combinator::cond;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// fn parser(b: bool, i: &str) -> IResult<&str, Option<&str>> {
@@ -588,7 +588,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::peek;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = peek(alpha1);
@@ -643,15 +643,15 @@ where
 /// Transforms Incomplete into `Error`.
 ///
 /// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult};
-/// use nom::bytes::streaming::take;
+/// # use nom::{Err,error::ErrorKind, IResult, input::Streaming};
+/// use nom::bytes::take;
 /// use nom::combinator::complete;
 /// # fn main() {
 ///
 /// let mut parser = complete(take(5u8));
 ///
-/// assert_eq!(parser("abcdefg"), Ok(("fg", "abcde")));
-/// assert_eq!(parser("abcd"), Err(Err::Error(("abcd", ErrorKind::Complete))));
+/// assert_eq!(parser(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
+/// assert_eq!(parser(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
 pub fn complete<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
@@ -672,7 +672,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::all_consuming;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = all_consuming(alpha1);
@@ -705,7 +705,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::verify;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = verify(alpha1, |s: &str| s.len() == 4);
@@ -742,7 +742,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::value;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = value(1234, alpha1);
@@ -766,7 +766,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::not;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = not(alpha1);
@@ -794,7 +794,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::recognize;
-/// use nom::character::complete::{char, alpha1};
+/// use nom::character::{char, alpha1};
 /// use nom::sequence::separated_pair;
 /// # fn main() {
 ///
@@ -838,8 +838,8 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::{consumed, value, recognize, map};
-/// use nom::character::complete::{char, alpha1};
-/// use nom::bytes::complete::tag;
+/// use nom::character::{char, alpha1};
+/// use nom::bytes::tag;
 /// use nom::sequence::separated_pair;
 ///
 /// fn inner_parser(input: &str) -> IResult<&str, bool> {
@@ -890,7 +890,7 @@ where
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::cut;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 /// let mut parser = cut(alpha1);
@@ -917,7 +917,7 @@ where
 /// ```rust
 /// # use nom::IResult;
 /// use nom::combinator::into;
-/// use nom::character::complete::alpha1;
+/// use nom::character::alpha1;
 /// # fn main() {
 ///
 ///  fn parser1(i: &str) -> IResult<&str, &str> {
@@ -995,7 +995,7 @@ impl<
 /// or the error value if we encountered an error.
 ///
 /// ```rust
-/// use nom::{combinator::iterator, IResult, bytes::complete::tag, character::complete::alpha1, sequence::terminated};
+/// use nom::{combinator::iterator, IResult, bytes::tag, character::alpha1, sequence::terminated};
 /// use std::collections::HashMap;
 ///
 /// let data = "abc|defg|hijkl|mnopqr|123";
@@ -1095,7 +1095,7 @@ enum State<E> {
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::branch::alt;
 /// use nom::combinator::{success, value};
-/// use nom::character::complete::char;
+/// use nom::character::char;
 /// # fn main() {
 ///
 /// let mut parser = success::<_,_,(_,ErrorKind)>(10);

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@
 //! ```rust,ignore
 //! # use nom::IResult;
 //! # use nom::prelude::*;
-//! # let parser = nom::bytes::complete::take_while1(|c: char| c == ' ');
+//! # let parser = nom::bytes::take_while1(|c: char| c == ' ');
 //! # let input = " ";
 //! let parser_result: IResult<_, _, _> = parser(input);
 //! let result: Result<_, _> = parser_result.finish();
@@ -53,7 +53,7 @@
 //! ```rust,ignore
 //! # use nom::Err;
 //! # type Value<'s> = &'s [u8];
-//! # let parser = nom::bytes::complete::take_while1(|c: u8| c == b' ');
+//! # let parser = nom::bytes::take_while1(|c: u8| c == b' ');
 //! # let data = " ";
 //! let result: Result<(&[u8], Value<'_>), Err<Vec<u8>>> =
 //!   parser(data).map_err(|e: E<&[u8]>| e.to_owned());
@@ -177,10 +177,10 @@
 //! ```rust,ignore
 //! # use nom::error::context;
 //! # use nom::sequence::preceded;
-//! # use nom::character::complete::char;
+//! # use nom::character::char;
 //! # use nom::combinator::cut;
 //! # use nom::sequence::terminated;
-//! # let parse_str = nom::bytes::complete::take_while1(|c| c == ' ');
+//! # let parse_str = nom::bytes::take_while1(|c| c == ' ');
 //! # let i = " ";
 //! context(
 //!   "string",
@@ -461,7 +461,7 @@
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 //! # use nom::IResult;
 //! # use nom::error::dbg_dmp;
-//! # use nom::bytes::complete::tag;
+//! # use nom::bytes::tag;
 //! fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
 //!     dbg_dmp(tag("abcd"), "tag")(i)
 //! }
@@ -1039,7 +1039,7 @@ macro_rules! error_node_position(
 /// It also displays the input in hexdump format
 ///
 /// ```rust
-/// use nom::{IResult, error::dbg_dmp, bytes::complete::tag};
+/// use nom::{IResult, error::dbg_dmp, bytes::tag};
 ///
 /// fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
 ///   dbg_dmp(tag("abcd"), "tag")(i)
@@ -1074,7 +1074,7 @@ where
 #[cfg(feature = "alloc")]
 mod tests {
   use super::*;
-  use crate::character::complete::char;
+  use crate::character::char;
 
   #[test]
   fn convert_error_panic() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1632,6 +1632,8 @@ pub trait IntoOutput {
   type Output;
   /// Convert an `Input` into an appropriate `Output` type
   fn into_output(self) -> Self::Output;
+  /// Convert an `Output` type to be used as `Input`
+  fn from_output(inner: Self::Output) -> Self;
 }
 
 impl<'a, T> IntoOutput for &'a [T] {
@@ -1639,6 +1641,10 @@ impl<'a, T> IntoOutput for &'a [T] {
   #[inline]
   fn into_output(self) -> Self::Output {
     self
+  }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    inner
   }
 }
 
@@ -1648,6 +1654,10 @@ impl<const LEN: usize> IntoOutput for [u8; LEN] {
   fn into_output(self) -> Self::Output {
     self
   }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    inner
+  }
 }
 
 impl<'a, const LEN: usize> IntoOutput for &'a [u8; LEN] {
@@ -1655,6 +1665,10 @@ impl<'a, const LEN: usize> IntoOutput for &'a [u8; LEN] {
   #[inline]
   fn into_output(self) -> Self::Output {
     self
+  }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    inner
   }
 }
 
@@ -1664,6 +1678,10 @@ impl<'a> IntoOutput for &'a str {
   fn into_output(self) -> Self::Output {
     self
   }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    inner
+  }
 }
 
 impl<'a> IntoOutput for (&'a [u8], usize) {
@@ -1671,6 +1689,10 @@ impl<'a> IntoOutput for (&'a [u8], usize) {
   #[inline]
   fn into_output(self) -> Self::Output {
     self
+  }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    inner
   }
 }
 
@@ -1682,6 +1704,10 @@ where
   #[inline]
   fn into_output(self) -> Self::Output {
     self.into_complete().into_output()
+  }
+  #[inline]
+  fn from_output(inner: Self::Output) -> Self {
+    Streaming(T::from_output(inner))
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,6 +32,7 @@
 //! | [FindToken] |Look for self in the given input stream|
 //! | [InputIter] |Common iteration operations on the input type|
 //! | [InputLength] |Calculate the input length|
+//! | [IntoOutput] |Adapt a captired `Input` into an appropriate type|
 //! | [InputTake] |Slicing operations|
 //! | [InputTakeAtPosition] |Look for a specific token and split at its position|
 //! | [Offset] |Calculate the offset between slices|
@@ -1182,6 +1183,54 @@ macro_rules! slice_ranges_impl {
 
 slice_ranges_impl! {[T]}
 slice_ranges_impl! {str}
+
+/// Convert an `Input` into an appropriate `Output` type
+pub trait IntoOutput {
+  /// Output type
+  type Output;
+  /// Convert an `Input` into an appropriate `Output` type
+  fn into_output(self) -> Self::Output;
+}
+
+impl<'a, T> IntoOutput for &'a [T] {
+  type Output = Self;
+  #[inline]
+  fn into_output(self) -> Self::Output {
+    self
+  }
+}
+
+impl<const LEN: usize> IntoOutput for [u8; LEN] {
+  type Output = Self;
+  #[inline]
+  fn into_output(self) -> Self::Output {
+    self
+  }
+}
+
+impl<'a, const LEN: usize> IntoOutput for &'a [u8; LEN] {
+  type Output = Self;
+  #[inline]
+  fn into_output(self) -> Self::Output {
+    self
+  }
+}
+
+impl<'a> IntoOutput for &'a str {
+  type Output = Self;
+  #[inline]
+  fn into_output(self) -> Self::Output {
+    self
+  }
+}
+
+impl<'a> IntoOutput for (&'a [u8], usize) {
+  type Output = Self;
+  #[inline]
+  fn into_output(self) -> Self::Output {
+    self
+  }
+}
 
 /// Abstracts something which can extend an `Extend`.
 /// Used to build modified input slices in `escaped_transform`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```rust
 //! use nom::prelude::*;
-//! use nom::bytes::complete::{tag, take_while_m_n};
+//! use nom::bytes::{tag, take_while_m_n};
 //! use nom::combinator::map_res;
 //! use nom::sequence::tuple;
 //!
@@ -90,8 +90,8 @@
 //!   IResult,
 //!   sequence::delimited,
 //!   // see the "streaming/complete" paragraph lower for an explanation of these submodules
-//!   character::complete::char,
-//!   bytes::complete::is_not
+//!   character::char,
+//!   bytes::is_not
 //! };
 //!
 //! fn parens(input: &str) -> IResult<&str, &str> {
@@ -127,8 +127,8 @@
 //! With functions, you would write it like this:
 //!
 //! ```rust
-//! use nom::{IResult, bytes::streaming::take};
-//! fn take4(input: &str) -> IResult<&str, &str> {
+//! use nom::{IResult, bytes::take, input::Streaming};
+//! fn take4(input: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
 //!   take(4u8)(input)
 //! }
 //! ```
@@ -183,7 +183,7 @@
 //!
 //! ```rust
 //! use nom::IResult;
-//! use nom::bytes::complete::{tag, take};
+//! use nom::bytes::{tag, take};
 //! fn abcd_parser(i: &str) -> IResult<&str, &str> {
 //!   tag("abcd")(i) // will consume bytes if the input begins with "abcd"
 //! }
@@ -202,7 +202,7 @@
 //! ```rust
 //! use nom::IResult;
 //! use nom::branch::alt;
-//! use nom::bytes::complete::tag;
+//! use nom::bytes::tag;
 //!
 //! let mut alt_tags = alt((tag("abcd"), tag("efgh")));
 //!
@@ -215,7 +215,7 @@
 //! an error, **`opt`** will still succeed and return None:
 //!
 //! ```rust
-//! use nom::{IResult, combinator::opt, bytes::complete::tag};
+//! use nom::{IResult, combinator::opt, bytes::tag};
 //! fn abcd_opt(i: &[u8]) -> IResult<&[u8], Option<&[u8]>> {
 //!   opt(tag("abcd"))(i)
 //! }
@@ -229,7 +229,7 @@
 //! ```rust
 //! # #[cfg(feature = "alloc")]
 //! # fn main() {
-//! use nom::{IResult, multi::many0, bytes::complete::tag};
+//! use nom::{IResult, multi::many0, bytes::tag};
 //! use std::str;
 //!
 //! fn multi(i: &str) -> IResult<&str, Vec<&str>> {
@@ -260,23 +260,26 @@
 //!
 //! ```rust
 //! # fn main() {
-//! use nom::{error::ErrorKind, Needed,
-//! number::streaming::be_u16,
-//! bytes::streaming::{tag, take},
-//! sequence::tuple};
+//! use nom::{
+//!     error::ErrorKind, Needed,
+//!     number::be_u16,
+//!     bytes::{tag, take},
+//!     sequence::tuple,
+//!     input::Streaming,
+//! };
 //!
 //! let mut tpl = tuple((be_u16, take(3u8), tag("fg")));
 //!
 //! assert_eq!(
-//!   tpl(&b"abcdefgh"[..]),
+//!   tpl(Streaming(&b"abcdefgh"[..])),
 //!   Ok((
-//!     &b"h"[..],
+//!     Streaming(&b"h"[..]),
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl(&b"abcde"[..]), Err(nom::Err::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl(Streaming(&b"abcde"[..])), Err(nom::Err::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl(input), Err(nom::Err::Error((&input[5..], ErrorKind::Tag))));
+//! assert_eq!(tpl(Streaming(input)), Err(nom::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!
@@ -285,7 +288,7 @@
 //!
 //! ```rust
 //! # fn main() {
-//! use nom::{IResult, bytes::complete::tag};
+//! use nom::{IResult, bytes::tag};
 //!
 //! #[derive(Debug, PartialEq)]
 //! struct A {
@@ -327,44 +330,44 @@
 //! Here is how it works in practice:
 //!
 //! ```rust
-//! use nom::{IResult, Err, Needed, error::{Error, ErrorKind}, bytes, character};
+//! use nom::{IResult, Err, Needed, error::{Error, ErrorKind}, bytes, character, input::Streaming};
 //!
-//! fn take_streaming(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   bytes::streaming::take(4u8)(i)
+//! fn take_streaming(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+//!   bytes::take(4u8)(i)
 //! }
 //!
 //! fn take_complete(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   bytes::complete::take(4u8)(i)
+//!   bytes::take(4u8)(i)
 //! }
 //!
 //! // both parsers will take 4 bytes as expected
-//! assert_eq!(take_streaming(&b"abcde"[..]), Ok((&b"e"[..], &b"abcd"[..])));
+//! assert_eq!(take_streaming(Streaming(&b"abcde"[..])), Ok((Streaming(&b"e"[..]), &b"abcd"[..])));
 //! assert_eq!(take_complete(&b"abcde"[..]), Ok((&b"e"[..], &b"abcd"[..])));
 //!
 //! // if the input is smaller than 4 bytes, the streaming parser
 //! // will return `Incomplete` to indicate that we need more data
-//! assert_eq!(take_streaming(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+//! assert_eq!(take_streaming(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
 //!
 //! // but the complete parser will return an error
 //! assert_eq!(take_complete(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 //!
 //! // the alpha0 function recognizes 0 or more alphabetic characters
-//! fn alpha0_streaming(i: &str) -> IResult<&str, &str> {
-//!   character::streaming::alpha0(i)
+//! fn alpha0_streaming(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+//!   character::alpha0(i)
 //! }
 //!
 //! fn alpha0_complete(i: &str) -> IResult<&str, &str> {
-//!   character::complete::alpha0(i)
+//!   character::alpha0(i)
 //! }
 //!
 //! // if there's a clear limit to the recognized characters, both parsers work the same way
-//! assert_eq!(alpha0_streaming("abcd;"), Ok((";", "abcd")));
+//! assert_eq!(alpha0_streaming(Streaming("abcd;")), Ok((Streaming(";"), "abcd")));
 //! assert_eq!(alpha0_complete("abcd;"), Ok((";", "abcd")));
 //!
 //! // but when there's no limit, the streaming version returns `Incomplete`, because it cannot
 //! // know if more input data should be recognized. The whole input could be "abcd;", or
 //! // "abcde;"
-//! assert_eq!(alpha0_streaming("abcd"), Err(Err::Incomplete(Needed::new(1))));
+//! assert_eq!(alpha0_streaming(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
 //!
 //! // while the complete version knows that all of the data is there
 //! assert_eq!(alpha0_complete("abcd"), Ok(("", "abcd")));
@@ -477,7 +480,7 @@ pub mod _tutorial;
 ///
 /// fn parse_data(input: &str) -> IResult<&str, u64> {
 ///     // ...
-/// #   nom::character::complete::u64(input)
+/// #   nom::character::u64(input)
 /// }
 ///
 /// fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 //! # nom, eating data byte by byte
 //!
-//! nom is a parser combinator library with a focus on safe parsing,
-//! streaming patterns, and as much as possible zero copy.
+//! nom is a parser combinator library, supporting:
+//! - String (`&str`), byte (`&[u8]`), and [custom input types][crate::input]
+//! - [Streaming parsing][crate::input::Streaming]
+//! - Zero copy parsing
 //!
 //! ## Example
 //!
@@ -313,67 +315,6 @@
 //! assert_eq!(r, Ok((&b"X"[..], A{a: 1, b: 2})));
 //! # }
 //! ```
-//!
-//! ## Streaming / Complete
-//!
-//! Some of nom's modules have `streaming` or `complete` submodules. They hold
-//! different variants of the same combinators.
-//!
-//! A streaming parser assumes that we might not have all of the input data.
-//! This can happen with some network protocol or large file parsers, where the
-//! input buffer can be full and need to be resized or refilled.
-//!
-//! A complete parser assumes that we already have all of the input data.
-//! This will be the common case with small files that can be read entirely to
-//! memory.
-//!
-//! Here is how it works in practice:
-//!
-//! ```rust
-//! use nom::{IResult, Err, Needed, error::{Error, ErrorKind}, bytes, character, input::Streaming};
-//!
-//! fn take_streaming(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-//!   bytes::take(4u8)(i)
-//! }
-//!
-//! fn take_complete(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   bytes::take(4u8)(i)
-//! }
-//!
-//! // both parsers will take 4 bytes as expected
-//! assert_eq!(take_streaming(Streaming(&b"abcde"[..])), Ok((Streaming(&b"e"[..]), &b"abcd"[..])));
-//! assert_eq!(take_complete(&b"abcde"[..]), Ok((&b"e"[..], &b"abcd"[..])));
-//!
-//! // if the input is smaller than 4 bytes, the streaming parser
-//! // will return `Incomplete` to indicate that we need more data
-//! assert_eq!(take_streaming(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
-//!
-//! // but the complete parser will return an error
-//! assert_eq!(take_complete(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
-//!
-//! // the alpha0 function recognizes 0 or more alphabetic characters
-//! fn alpha0_streaming(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
-//!   character::alpha0(i)
-//! }
-//!
-//! fn alpha0_complete(i: &str) -> IResult<&str, &str> {
-//!   character::alpha0(i)
-//! }
-//!
-//! // if there's a clear limit to the recognized characters, both parsers work the same way
-//! assert_eq!(alpha0_streaming(Streaming("abcd;")), Ok((Streaming(";"), "abcd")));
-//! assert_eq!(alpha0_complete("abcd;"), Ok((";", "abcd")));
-//!
-//! // but when there's no limit, the streaming version returns `Incomplete`, because it cannot
-//! // know if more input data should be recognized. The whole input could be "abcd;", or
-//! // "abcde;"
-//! assert_eq!(alpha0_streaming(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
-//!
-//! // while the complete version knows that all of the data is there
-//! assert_eq!(alpha0_complete("abcd"), Ok(("", "abcd")));
-//! ```
-//! **Going further:** Read the [guides](https://github.com/Geal/nom/tree/main/doc),
-//! check out the [_cookbook]!
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(extended_key_value_attributes))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,6 +486,7 @@ pub mod _tutorial;
 /// }
 /// ```
 pub mod prelude {
+  pub use crate::input::InputIsStreaming as _;
   pub use crate::FinishIResult as _;
   pub use crate::IResult;
   pub use crate::IntoOutputIResult as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,5 +488,6 @@ pub mod _tutorial;
 pub mod prelude {
   pub use crate::FinishIResult as _;
   pub use crate::IResult;
+  pub use crate::IntoOutputIResult as _;
   pub use crate::Parser as _;
 }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -37,7 +37,7 @@ const MAX_INITIAL_CAPACITY: usize = 65536;
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::many0;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   many0(tag("abc"))(s)
@@ -91,7 +91,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::many1;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   many1(tag("abc"))(s)
@@ -143,7 +143,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::many_till;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
 ///   many_till(tag("abc"), tag("end"))(s)
@@ -202,7 +202,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::separated_list0;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated_list0(tag("|"), tag("abc"))(s)
@@ -271,7 +271,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::separated_list1;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated_list1(tag("|"), tag("abc"))(s)
@@ -341,7 +341,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::many_m_n;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   many_m_n(0, 2, tag("abc"))(s)
@@ -406,7 +406,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::many0_count;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, usize> {
 ///   many0_count(tag("abc"))(s)
@@ -458,7 +458,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::many1_count;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, usize> {
 ///   many1_count(tag("abc"))(s)
@@ -514,7 +514,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::count;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   count(tag("abc"), 2)(s)
@@ -565,7 +565,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::fill;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
 ///   let mut buf = ["", ""];
@@ -618,7 +618,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::fold_many0;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   fold_many0(
@@ -688,7 +688,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::multi::fold_many1;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   fold_many1(
@@ -768,7 +768,7 @@ where
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::fold_many_m_n;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   fold_many_m_n(
@@ -843,9 +843,9 @@ where
 /// * `f` The parser to apply.
 /// ```rust
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::number::complete::be_u16;
+/// use nom::number::be_u16;
 /// use nom::multi::length_data;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
 ///   length_data(be_u16)(s)
@@ -889,9 +889,9 @@ where
 /// * `g` The parser to apply on the subslice.
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::number::complete::be_u16;
+/// use nom::number::be_u16;
 /// use nom::multi::length_value;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
 ///   length_value(be_u16, tag("abc"))(s)
@@ -923,9 +923,9 @@ where
 /// * `g` The parser to apply repeatedly.
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::number::complete::u8;
+/// use nom::number::u8;
 /// use nom::multi::length_count;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 /// use nom::combinator::map;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -1,10 +1,11 @@
 use super::{length_data, length_value, many0_count, many1_count};
+use crate::input::Streaming;
 use crate::{
-  bytes::streaming::tag,
-  character::streaming::digit1 as digit,
+  bytes::tag,
+  character::digit1 as digit,
   error::{ErrorKind, ParseError},
   lib::std::str::{self, FromStr},
-  number::streaming::{be_u16, be_u8},
+  number::{be_u16, be_u8},
   sequence::{pair, tuple},
   {Err, IResult, Needed},
 };
@@ -20,16 +21,16 @@ use crate::{
 #[test]
 #[cfg(feature = "alloc")]
 fn separated_list0_test() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list0(tag(","), tag("abcd"))(i)
   }
-  fn multi_empty(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_empty(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list0(tag(","), tag(""))(i)
   }
-  fn empty_sep(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn empty_sep(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list0(tag(""), tag("abc"))(i)
   }
-  fn multi_longsep(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_longsep(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list0(tag(".."), tag("abcd"))(i)
   }
 
@@ -44,35 +45,44 @@ fn separated_list0_test() {
   let i = &b"abcabc"[..];
 
   let res1 = vec![&b"abcd"[..]];
-  assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
+  assert_eq!(multi(Streaming(a)), Ok((Streaming(&b"ef"[..]), res1)));
   let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"ef"[..], res2)));
-  assert_eq!(multi(c), Ok((&b"azerty"[..], Vec::new())));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"ef"[..]), res2)));
+  assert_eq!(
+    multi(Streaming(c)),
+    Ok((Streaming(&b"azerty"[..]), Vec::new()))
+  );
   let res3 = vec![&b""[..], &b""[..], &b""[..]];
-  assert_eq!(multi_empty(d), Ok((&b"abc"[..], res3)));
+  assert_eq!(
+    multi_empty(Streaming(d)),
+    Ok((Streaming(&b"abc"[..]), res3))
+  );
   let i_err_pos = &i[3..];
   assert_eq!(
-    empty_sep(i),
+    empty_sep(Streaming(i)),
     Err(Err::Error(error_position!(
-      i_err_pos,
+      Streaming(i_err_pos),
       ErrorKind::SeparatedList
     )))
   );
   let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(e), Ok((&b",ef"[..], res4)));
+  assert_eq!(multi(Streaming(e)), Ok((Streaming(&b",ef"[..]), res4)));
 
-  assert_eq!(multi(f), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(multi_longsep(g), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(multi(h), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(multi(Streaming(f)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(
+    multi_longsep(Streaming(g)),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(multi(Streaming(h)), Err(Err::Incomplete(Needed::new(1))));
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn separated_list1_test() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list1(tag(","), tag("abcd"))(i)
   }
-  fn multi_longsep(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_longsep(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     separated_list1(tag(".."), tag("abcd"))(i)
   }
 
@@ -86,44 +96,62 @@ fn separated_list1_test() {
   let h = &b"abcd,abc"[..];
 
   let res1 = vec![&b"abcd"[..]];
-  assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
+  assert_eq!(multi(Streaming(a)), Ok((Streaming(&b"ef"[..]), res1)));
   let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"ef"[..], res2)));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"ef"[..]), res2)));
   assert_eq!(
-    multi(c),
-    Err(Err::Error(error_position!(c, ErrorKind::Tag)))
+    multi(Streaming(c)),
+    Err(Err::Error(error_position!(Streaming(c), ErrorKind::Tag)))
   );
   let res3 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(d), Ok((&b",ef"[..], res3)));
+  assert_eq!(multi(Streaming(d)), Ok((Streaming(&b",ef"[..]), res3)));
 
-  assert_eq!(multi(f), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(multi_longsep(g), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(multi(h), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(multi(Streaming(f)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(
+    multi_longsep(Streaming(g)),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(multi(Streaming(h)), Err(Err::Incomplete(Needed::new(1))));
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn many0_test() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     many0(tag("abcd"))(i)
   }
-  fn multi_empty(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_empty(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     many0(tag(""))(i)
   }
 
-  assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
   assert_eq!(
-    multi(&b"abcdabcdefgh"[..]),
-    Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
+    multi(Streaming(&b"abcdef"[..])),
+    Ok((Streaming(&b"ef"[..]), vec![&b"abcd"[..]]))
   );
-  assert_eq!(multi(&b"azerty"[..]), Ok((&b"azerty"[..], Vec::new())));
-  assert_eq!(multi(&b"abcdab"[..]), Err(Err::Incomplete(Needed::new(2))));
-  assert_eq!(multi(&b"abcd"[..]), Err(Err::Incomplete(Needed::new(4))));
-  assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
   assert_eq!(
-    multi_empty(&b"abcdef"[..]),
+    multi(Streaming(&b"abcdabcdefgh"[..])),
+    Ok((Streaming(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
+  );
+  assert_eq!(
+    multi(Streaming(&b"azerty"[..])),
+    Ok((Streaming(&b"azerty"[..]), Vec::new()))
+  );
+  assert_eq!(
+    multi(Streaming(&b"abcdab"[..])),
+    Err(Err::Incomplete(Needed::new(2)))
+  );
+  assert_eq!(
+    multi(Streaming(&b"abcd"[..])),
+    Err(Err::Incomplete(Needed::new(4)))
+  );
+  assert_eq!(
+    multi(Streaming(&b""[..])),
+    Err(Err::Incomplete(Needed::new(4)))
+  );
+  assert_eq!(
+    multi_empty(Streaming(&b"abcdef"[..])),
     Err(Err::Error(error_position!(
-      &b"abcdef"[..],
+      Streaming(&b"abcdef"[..]),
       ErrorKind::Many0
     )))
   );
@@ -132,7 +160,7 @@ fn many0_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn many1_test() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     many1(tag("abcd"))(i)
   }
 
@@ -142,14 +170,14 @@ fn many1_test() {
   let d = &b"abcdab"[..];
 
   let res1 = vec![&b"abcd"[..]];
-  assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
+  assert_eq!(multi(Streaming(a)), Ok((Streaming(&b"ef"[..]), res1)));
   let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"efgh"[..], res2)));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res2)));
   assert_eq!(
-    multi(c),
-    Err(Err::Error(error_position!(c, ErrorKind::Tag)))
+    multi(Streaming(c)),
+    Err(Err::Error(error_position!(Streaming(c), ErrorKind::Tag)))
   );
-  assert_eq!(multi(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(multi(Streaming(d)), Err(Err::Incomplete(Needed::new(2))));
 }
 
 #[test]
@@ -205,7 +233,7 @@ fn infinite_many() {
 #[test]
 #[cfg(feature = "alloc")]
 fn many_m_n_test() {
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     many_m_n(2, 4, tag("Abcd"))(i)
   }
 
@@ -216,47 +244,59 @@ fn many_m_n_test() {
   let e = &b"AbcdAb"[..];
 
   assert_eq!(
-    multi(a),
-    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+    multi(Streaming(a)),
+    Err(Err::Error(error_position!(
+      Streaming(&b"ef"[..]),
+      ErrorKind::Tag
+    )))
   );
   let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"efgh"[..], res1)));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res1)));
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(c), Ok((&b"efgh"[..], res2)));
+  assert_eq!(multi(Streaming(c)), Ok((Streaming(&b"efgh"[..]), res2)));
   let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(d), Ok((&b"Abcdefgh"[..], res3)));
-  assert_eq!(multi(e), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(multi(Streaming(d)), Ok((Streaming(&b"Abcdefgh"[..]), res3)));
+  assert_eq!(multi(Streaming(e)), Err(Err::Incomplete(Needed::new(2))));
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn count_test() {
   const TIMES: usize = 2;
-  fn cnt_2(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn cnt_2(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     count(tag("abc"), TIMES)(i)
   }
 
   assert_eq!(
-    cnt_2(&b"abcabcabcdef"[..]),
-    Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]]))
-  );
-  assert_eq!(cnt_2(&b"ab"[..]), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(cnt_2(&b"abcab"[..]), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(
-    cnt_2(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    cnt_2(Streaming(&b"abcabcabcdef"[..])),
+    Ok((Streaming(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
   );
   assert_eq!(
-    cnt_2(&b"xxxabcabcdef"[..]),
+    cnt_2(Streaming(&b"ab"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    cnt_2(Streaming(&b"abcab"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    cnt_2(Streaming(&b"xxx"[..])),
     Err(Err::Error(error_position!(
-      &b"xxxabcabcdef"[..],
+      Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
-    cnt_2(&b"abcxxxabcdef"[..]),
+    cnt_2(Streaming(&b"xxxabcabcdef"[..])),
     Err(Err::Error(error_position!(
-      &b"xxxabcdef"[..],
+      Streaming(&b"xxxabcabcdef"[..]),
+      ErrorKind::Tag
+    )))
+  );
+  assert_eq!(
+    cnt_2(Streaming(&b"abcxxxabcdef"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxabcdef"[..]),
       ErrorKind::Tag
     )))
   );
@@ -319,89 +359,140 @@ impl<I> ParseError<I> for NilError {
   }
 }
 
-fn number(i: &[u8]) -> IResult<&[u8], u32> {
-  use crate::combinator::map_res;
-
-  map_res(map_res(digit, str::from_utf8), FromStr::from_str)(i)
-}
-
 #[test]
 #[cfg(feature = "alloc")]
 fn length_count_test() {
-  fn cnt(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn number(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
+    use crate::combinator::map_res;
+
+    map_res(map_res(digit, str::from_utf8), FromStr::from_str)(i)
+  }
+
+  fn cnt(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     length_count(number, tag("abc"))(i)
   }
 
   assert_eq!(
-    cnt(&b"2abcabcabcdef"[..]),
-    Ok((&b"abcdef"[..], vec![&b"abc"[..], &b"abc"[..]]))
-  );
-  assert_eq!(cnt(&b"2ab"[..]), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(cnt(&b"3abcab"[..]), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(
-    cnt(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit)))
+    cnt(Streaming(&b"2abcabcabcdef"[..])),
+    Ok((Streaming(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
   );
   assert_eq!(
-    cnt(&b"2abcxxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    cnt(Streaming(&b"2ab"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    cnt(Streaming(&b"3abcab"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    cnt(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Digit
+    )))
+  );
+  assert_eq!(
+    cnt(Streaming(&b"2abcxxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn length_data_test() {
-  fn take(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn number(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
+    use crate::combinator::map_res;
+
+    map_res(map_res(digit, str::from_utf8), FromStr::from_str)(i)
+  }
+
+  fn take(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     length_data(number)(i)
   }
 
   assert_eq!(
-    take(&b"6abcabcabcdef"[..]),
-    Ok((&b"abcdef"[..], &b"abcabc"[..]))
+    take(Streaming(&b"6abcabcabcdef"[..])),
+    Ok((Streaming(&b"abcdef"[..]), &b"abcabc"[..]))
   );
-  assert_eq!(take(&b"3ab"[..]), Err(Err::Incomplete(Needed::new(1))));
   assert_eq!(
-    take(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Digit)))
+    take(Streaming(&b"3ab"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
   );
-  assert_eq!(take(&b"2abcxxx"[..]), Ok((&b"cxxx"[..], &b"ab"[..])));
+  assert_eq!(
+    take(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Digit
+    )))
+  );
+  assert_eq!(
+    take(Streaming(&b"2abcxxx"[..])),
+    Ok((Streaming(&b"cxxx"[..]), &b"ab"[..]))
+  );
 }
 
 #[test]
 fn length_value_test() {
-  fn length_value_1(i: &[u8]) -> IResult<&[u8], u16> {
+  fn length_value_1(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u16> {
     length_value(be_u8, be_u16)(i)
   }
-  fn length_value_2(i: &[u8]) -> IResult<&[u8], (u8, u8)> {
+  fn length_value_2(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (u8, u8)> {
     length_value(be_u8, tuple((be_u8, be_u8)))(i)
   }
 
   let i1 = [0, 5, 6];
   assert_eq!(
-    length_value_1(&i1),
-    Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete)))
+    length_value_1(Streaming(&i1)),
+    Err(Err::Error(error_position!(
+      Streaming(&b""[..]),
+      ErrorKind::Complete
+    )))
   );
   assert_eq!(
-    length_value_2(&i1),
-    Err(Err::Error(error_position!(&b""[..], ErrorKind::Complete)))
+    length_value_2(Streaming(&i1)),
+    Err(Err::Error(error_position!(
+      Streaming(&b""[..]),
+      ErrorKind::Complete
+    )))
   );
 
   let i2 = [1, 5, 6, 3];
   assert_eq!(
-    length_value_1(&i2),
-    Err(Err::Error(error_position!(&i2[1..2], ErrorKind::Complete)))
+    length_value_1(Streaming(&i2)),
+    Err(Err::Error(error_position!(
+      Streaming(&i2[1..2]),
+      ErrorKind::Complete
+    )))
   );
   assert_eq!(
-    length_value_2(&i2),
-    Err(Err::Error(error_position!(&i2[1..2], ErrorKind::Complete)))
+    length_value_2(Streaming(&i2)),
+    Err(Err::Error(error_position!(
+      Streaming(&i2[1..2]),
+      ErrorKind::Complete
+    )))
   );
 
   let i3 = [2, 5, 6, 3, 4, 5, 7];
-  assert_eq!(length_value_1(&i3), Ok((&i3[3..], 1286)));
-  assert_eq!(length_value_2(&i3), Ok((&i3[3..], (5, 6))));
+  assert_eq!(
+    length_value_1(Streaming(&i3)),
+    Ok((Streaming(&i3[3..]), 1286))
+  );
+  assert_eq!(
+    length_value_2(Streaming(&i3)),
+    Ok((Streaming(&i3[3..]), (5, 6)))
+  );
 
   let i4 = [3, 5, 6, 3, 4, 5];
-  assert_eq!(length_value_1(&i4), Ok((&i4[4..], 1286)));
-  assert_eq!(length_value_2(&i4), Ok((&i4[4..], (5, 6))));
+  assert_eq!(
+    length_value_1(Streaming(&i4)),
+    Ok((Streaming(&i4[4..]), 1286))
+  );
+  assert_eq!(
+    length_value_2(Streaming(&i4)),
+    Ok((Streaming(&i4[4..]), (5, 6)))
+  );
 }
 
 #[test]
@@ -411,26 +502,41 @@ fn fold_many0_test() {
     acc.push(item);
     acc
   }
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     fold_many0(tag("abcd"), Vec::new, fold_into_vec)(i)
   }
-  fn multi_empty(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_empty(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     fold_many0(tag(""), Vec::new, fold_into_vec)(i)
   }
 
-  assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
   assert_eq!(
-    multi(&b"abcdabcdefgh"[..]),
-    Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
+    multi(Streaming(&b"abcdef"[..])),
+    Ok((Streaming(&b"ef"[..]), vec![&b"abcd"[..]]))
   );
-  assert_eq!(multi(&b"azerty"[..]), Ok((&b"azerty"[..], Vec::new())));
-  assert_eq!(multi(&b"abcdab"[..]), Err(Err::Incomplete(Needed::new(2))));
-  assert_eq!(multi(&b"abcd"[..]), Err(Err::Incomplete(Needed::new(4))));
-  assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
   assert_eq!(
-    multi_empty(&b"abcdef"[..]),
+    multi(Streaming(&b"abcdabcdefgh"[..])),
+    Ok((Streaming(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
+  );
+  assert_eq!(
+    multi(Streaming(&b"azerty"[..])),
+    Ok((Streaming(&b"azerty"[..]), Vec::new()))
+  );
+  assert_eq!(
+    multi(Streaming(&b"abcdab"[..])),
+    Err(Err::Incomplete(Needed::new(2)))
+  );
+  assert_eq!(
+    multi(Streaming(&b"abcd"[..])),
+    Err(Err::Incomplete(Needed::new(4)))
+  );
+  assert_eq!(
+    multi(Streaming(&b""[..])),
+    Err(Err::Incomplete(Needed::new(4)))
+  );
+  assert_eq!(
+    multi_empty(Streaming(&b"abcdef"[..])),
     Err(Err::Error(error_position!(
-      &b"abcdef"[..],
+      Streaming(&b"abcdef"[..]),
       ErrorKind::Many0
     )))
   );
@@ -443,7 +549,7 @@ fn fold_many1_test() {
     acc.push(item);
     acc
   }
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     fold_many1(tag("abcd"), Vec::new, fold_into_vec)(i)
   }
 
@@ -453,14 +559,14 @@ fn fold_many1_test() {
   let d = &b"abcdab"[..];
 
   let res1 = vec![&b"abcd"[..]];
-  assert_eq!(multi(a), Ok((&b"ef"[..], res1)));
+  assert_eq!(multi(Streaming(a)), Ok((Streaming(&b"ef"[..]), res1)));
   let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"efgh"[..], res2)));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res2)));
   assert_eq!(
-    multi(c),
-    Err(Err::Error(error_position!(c, ErrorKind::Many1)))
+    multi(Streaming(c)),
+    Err(Err::Error(error_position!(Streaming(c), ErrorKind::Many1)))
   );
-  assert_eq!(multi(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(multi(Streaming(d)), Err(Err::Incomplete(Needed::new(2))));
 }
 
 #[test]
@@ -470,7 +576,7 @@ fn fold_many_m_n_test() {
     acc.push(item);
     acc
   }
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
     fold_many_m_n(2, 4, tag("Abcd"), Vec::new, fold_into_vec)(i)
   }
 
@@ -481,16 +587,19 @@ fn fold_many_m_n_test() {
   let e = &b"AbcdAb"[..];
 
   assert_eq!(
-    multi(a),
-    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+    multi(Streaming(a)),
+    Err(Err::Error(error_position!(
+      Streaming(&b"ef"[..]),
+      ErrorKind::Tag
+    )))
   );
   let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(b), Ok((&b"efgh"[..], res1)));
+  assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res1)));
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(c), Ok((&b"efgh"[..], res2)));
+  assert_eq!(multi(Streaming(c)), Ok((Streaming(&b"efgh"[..]), res2)));
   let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi(d), Ok((&b"Abcdefgh"[..], res3)));
-  assert_eq!(multi(e), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(multi(Streaming(d)), Ok((Streaming(&b"Abcdefgh"[..]), res3)));
+  assert_eq!(multi(Streaming(e)), Err(Err::Incomplete(Needed::new(2))));
 }
 
 #[test]

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1,5 +1,7 @@
 //! Parsers recognizing numbers, complete input version
 
+#![allow(deprecated)]
+
 use crate::branch::alt;
 use crate::bytes::complete::tag;
 use crate::character::complete::{char, digit1, sign};
@@ -30,6 +32,9 @@ use crate::*;
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u8`][crate::number::be_u8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u8`")]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -60,6 +65,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u16`][crate::number::be_u16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u16`")]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -93,6 +101,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u24`][crate::number::be_u24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u24`")]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -126,6 +137,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u32`][crate::number::be_u32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u32`")]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -159,6 +173,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u64`][crate::number::be_u64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u64`")]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -192,6 +209,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u128`][crate::number::be_u128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_u128`")]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -225,6 +245,9 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i8`][crate::number::be_i8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i8`")]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -248,6 +271,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i16`][crate::number::be_i16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i16`")]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -271,6 +297,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i24`][crate::number::be_i24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i24`")]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -303,6 +332,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i32`][crate::number::be_i32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i32`")]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -326,6 +358,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i64`][crate::number::be_i64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i64`")]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -349,6 +384,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i128`][crate::number::be_i128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_i128`")]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -372,6 +410,9 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u8`][crate::number::le_u8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u8`")]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -402,6 +443,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u16`][crate::number::le_u16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u16`")]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -435,6 +479,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u24`][crate::number::le_u24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u24`")]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -468,6 +515,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u32`][crate::number::le_u32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u32`")]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -501,6 +551,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u64`][crate::number::le_u64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u64`")]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -534,6 +587,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u128`][crate::number::le_u128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_u128`")]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -567,6 +623,9 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i8`][crate::number::le_i8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i8`")]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -590,6 +649,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i16`][crate::number::le_i16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i16`")]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -613,6 +675,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i24`][crate::number::le_i24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i24`")]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -645,6 +710,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i32`][crate::number::le_i32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i32`")]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -668,6 +736,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i64`][crate::number::le_i64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i64`")]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -691,6 +762,9 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i128`][crate::number::le_i128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_i128`")]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -715,6 +789,9 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u8`][crate::number::u8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u8`")]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -755,6 +832,9 @@ where
 /// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u16`][crate::number::u16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u16`")]
 pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -794,6 +874,9 @@ where
 /// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u24`][crate::number::u24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u24`")]
 pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -833,6 +916,9 @@ where
 /// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u32`][crate::number::u32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u32`")]
 pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -872,6 +958,9 @@ where
 /// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u64`][crate::number::u64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u64`")]
 pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -911,6 +1000,9 @@ where
 /// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u128`][crate::number::u128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::u128`")]
 pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -942,6 +1034,9 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i8`][crate::number::i8]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i8`")]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -974,6 +1069,9 @@ where
 /// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i16`][crate::number::i16]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i16`")]
 pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1013,6 +1111,9 @@ where
 /// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i24`][crate::number::i24]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i24`")]
 pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1052,6 +1153,9 @@ where
 /// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i32`][crate::number::i32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i32`")]
 pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1091,6 +1195,9 @@ where
 /// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i64`][crate::number::i64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i64`")]
 pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1130,6 +1237,9 @@ where
 /// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i128`][crate::number::i128]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::i128`")]
 pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1160,6 +1270,9 @@ where
 /// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_f32`][crate::number::be_f32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_f32`")]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1186,6 +1299,9 @@ where
 /// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_f64`][crate::number::be_f64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::be_f64`")]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1212,6 +1328,9 @@ where
 /// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_f32`][crate::number::le_f32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_f32`")]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1238,6 +1357,9 @@ where
 /// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_f64`][crate::number::le_f64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::le_f64`")]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1273,6 +1395,9 @@ where
 /// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::f32`][crate::number::f32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::f32`")]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1312,6 +1437,9 @@ where
 /// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::f64`][crate::number::f64]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::f64`")]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1343,6 +1471,9 @@ where
 /// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::hex_u32`][crate::number::hex_u32]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::hex_u32`")]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: InputTakeAtPosition,
@@ -1400,6 +1531,9 @@ where
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float`][crate::number::recognize_float]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::recognize_float`")]
 pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -1428,6 +1562,12 @@ where
 
 // workaround until issues with minimal-lexical are fixed
 #[doc(hidden)]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float_or_exceptions`][crate::number::recognize_float_or_exceptions]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::recognize_float_or_exceptions`"
+)]
 pub fn recognize_float_or_exceptions<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
@@ -1470,6 +1610,12 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float_parts`][crate::number::recognize_float_parts]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::recognize_float_parts`"
+)]
 pub fn recognize_float_parts<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<
@@ -1591,6 +1737,9 @@ use crate::input::ParseTo;
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::float`][crate::number::float]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::float`")]
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
@@ -1646,6 +1795,9 @@ where
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::double`][crate::number::double]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::double`")]
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1470,7 +1470,18 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-pub fn recognize_float_parts<T, E: ParseError<T>>(input: T) -> IResult<T, (bool, T, T, i32), E>
+pub fn recognize_float_parts<T, E: ParseError<T>>(
+  input: T,
+) -> IResult<
+  T,
+  (
+    bool,
+    <T as IntoOutput>::Output,
+    <T as IntoOutput>::Output,
+    i32,
+  ),
+  E,
+>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset,
@@ -1555,7 +1566,10 @@ where
     (i2, 0)
   };
 
-  Ok((i, (sign, integer, fraction, exp)))
+  Ok((
+    i,
+    (sign, integer.into_output(), fraction.into_output(), exp),
+  ))
 }
 
 use crate::input::ParseTo;

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -1,5 +1,7 @@
 //! Parsers recognizing numbers
 
+#![allow(deprecated)] // will just become `pub(crate)` later
+
 pub mod complete;
 pub mod streaming;
 #[cfg(test)]

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -2,6 +2,18 @@
 
 pub mod complete;
 pub mod streaming;
+#[cfg(test)]
+mod tests;
+
+use crate::error::ParseError;
+use crate::input::Compare;
+use crate::input::ParseTo;
+use crate::input::{
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtPosition,
+  IntoOutput, Offset, Slice,
+};
+use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
+use crate::IResult;
 
 /// Configurable endianness
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -12,4 +24,2394 @@ pub enum Endianness {
   Little,
   /// Will match the host's endianness
   Native,
+}
+
+/// Recognizes an unsigned 1 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u8;
+///
+/// let parser = |s| {
+///   be_u8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u8;
+///
+/// let parser = |s| {
+///   be_u8::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn be_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u8(input)
+  } else {
+    complete::be_u8(input)
+  }
+}
+
+/// Recognizes a big endian unsigned 2 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u16;
+///
+/// let parser = |s| {
+///   be_u16(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u16;
+///
+/// let parser = |s| {
+///   be_u16::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn be_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u16(input)
+  } else {
+    complete::be_u16(input)
+  }
+}
+
+/// Recognizes a big endian unsigned 3 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u24;
+///
+/// let parser = |s| {
+///   be_u24(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u24;
+///
+/// let parser = |s| {
+///   be_u24::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn be_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u24(input)
+  } else {
+    complete::be_u24(input)
+  }
+}
+
+/// Recognizes a big endian unsigned 4 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u32;
+///
+/// let parser = |s| {
+///   be_u32(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u32;
+///
+/// let parser = |s| {
+///   be_u32::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn be_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u32(input)
+  } else {
+    complete::be_u32(input)
+  }
+}
+
+/// Recognizes a big endian unsigned 8 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u64;
+///
+/// let parser = |s| {
+///   be_u64(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u64;
+///
+/// let parser = |s| {
+///   be_u64::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn be_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u64(input)
+  } else {
+    complete::be_u64(input)
+  }
+}
+
+/// Recognizes a big endian unsigned 16 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_u128;
+///
+/// let parser = |s| {
+///   be_u128(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_u128;
+///
+/// let parser = |s| {
+///   be_u128::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn be_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_u128(input)
+  } else {
+    complete::be_u128(input)
+  }
+}
+
+/// Recognizes a signed 1 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i8;
+///
+/// let parser = |s| {
+///   be_i8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i8;
+///
+/// let parser = be_i8::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn be_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i8(input)
+  } else {
+    complete::be_i8(input)
+  }
+}
+
+/// Recognizes a big endian signed 2 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i16;
+///
+/// let parser = |s| {
+///   be_i16(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i16;
+///
+/// let parser = be_i16::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn be_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i16(input)
+  } else {
+    complete::be_i16(input)
+  }
+}
+
+/// Recognizes a big endian signed 3 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i24;
+///
+/// let parser = |s| {
+///   be_i24(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i24;
+///
+/// let parser = be_i24::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn be_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i24(input)
+  } else {
+    complete::be_i24(input)
+  }
+}
+
+/// Recognizes a big endian signed 4 bytes integer.
+///
+/// *Complete version*: Teturns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i32;
+///
+/// let parser = |s| {
+///   be_i32(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i32;
+///
+/// let parser = be_i32::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(4))));
+/// ```
+#[inline(always)]
+pub fn be_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i32(input)
+  } else {
+    complete::be_i32(input)
+  }
+}
+
+/// Recognizes a big endian signed 8 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i64;
+///
+/// let parser = |s| {
+///   be_i64(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i64;
+///
+/// let parser = be_i64::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn be_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i64(input)
+  } else {
+    complete::be_i64(input)
+  }
+}
+
+/// Recognizes a big endian signed 16 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_i128;
+///
+/// let parser = |s| {
+///   be_i128(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_i128;
+///
+/// let parser = be_i128::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn be_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_i128(input)
+  } else {
+    complete::be_i128(input)
+  }
+}
+
+/// Recognizes an unsigned 1 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u8;
+///
+/// let parser = |s| {
+///   le_u8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u8;
+///
+/// let parser = le_u8::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn le_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u8(input)
+  } else {
+    complete::le_u8(input)
+  }
+}
+
+/// Recognizes a little endian unsigned 2 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u16;
+///
+/// let parser = |s| {
+///   le_u16(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u16;
+///
+/// let parser = |s| {
+///   le_u16::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn le_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u16(input)
+  } else {
+    complete::le_u16(input)
+  }
+}
+
+/// Recognizes a little endian unsigned 3 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u24;
+///
+/// let parser = |s| {
+///   le_u24(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u24;
+///
+/// let parser = |s| {
+///   le_u24::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn le_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u24(input)
+  } else {
+    complete::le_u24(input)
+  }
+}
+
+/// Recognizes a little endian unsigned 4 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u32;
+///
+/// let parser = |s| {
+///   le_u32(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u32;
+///
+/// let parser = |s| {
+///   le_u32::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn le_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u32(input)
+  } else {
+    complete::le_u32(input)
+  }
+}
+
+/// Recognizes a little endian unsigned 8 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u64;
+///
+/// let parser = |s| {
+///   le_u64(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u64;
+///
+/// let parser = |s| {
+///   le_u64::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn le_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u64(input)
+  } else {
+    complete::le_u64(input)
+  }
+}
+
+/// Recognizes a little endian unsigned 16 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_u128;
+///
+/// let parser = |s| {
+///   le_u128(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_u128;
+///
+/// let parser = |s| {
+///   le_u128::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn le_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_u128(input)
+  } else {
+    complete::le_u128(input)
+  }
+}
+
+/// Recognizes a signed 1 byte integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i8;
+///
+/// let parser = |s| {
+///   le_i8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i8;
+///
+/// let parser = le_i8::<_, (_, ErrorKind), true>;
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn le_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i8(input)
+  } else {
+    complete::le_i8(input)
+  }
+}
+
+/// Recognizes a little endian signed 2 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i16;
+///
+/// let parser = |s| {
+///   le_i16(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i16;
+///
+/// let parser = |s| {
+///   le_i16::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn le_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i16(input)
+  } else {
+    complete::le_i16(input)
+  }
+}
+
+/// Recognizes a little endian signed 3 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i24;
+///
+/// let parser = |s| {
+///   le_i24(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i24;
+///
+/// let parser = |s| {
+///   le_i24::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn le_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i24(input)
+  } else {
+    complete::le_i24(input)
+  }
+}
+
+/// Recognizes a little endian signed 4 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i32;
+///
+/// let parser = |s| {
+///   le_i32(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i32;
+///
+/// let parser = |s| {
+///   le_i32::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn le_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i32(input)
+  } else {
+    complete::le_i32(input)
+  }
+}
+
+/// Recognizes a little endian signed 8 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i64;
+///
+/// let parser = |s| {
+///   le_i64(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i64;
+///
+/// let parser = |s| {
+///   le_i64::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn le_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i64(input)
+  } else {
+    complete::le_i64(input)
+  }
+}
+
+/// Recognizes a little endian signed 16 bytes integer.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_i128;
+///
+/// let parser = |s| {
+///   le_i128(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_i128;
+///
+/// let parser = |s| {
+///   le_i128::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn le_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_i128(input)
+  } else {
+    complete::le_i128(input)
+  }
+}
+
+/// Recognizes an unsigned 1 byte integer
+///
+/// **Note:** that endianness does not apply to 1 byte numbers.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u8;
+///
+/// let parser = |s| {
+///   u8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u8;
+///
+/// let parser = |s| {
+///   u8::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u8(input)
+  } else {
+    complete::u8(input)
+  }
+}
+
+/// Recognizes an unsigned 2 bytes integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian u16 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian u16 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u16;
+///
+/// let be_u16 = |s| {
+///   u16(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_u16 = |s| {
+///   u16(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u16;
+///
+/// let be_u16 = |s| {
+///   u16::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_u16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+///
+/// let le_u16 = |s| {
+///   u16::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_u16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn u16<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, u16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u16(endian)
+  } else {
+    complete::u16(endian)
+  }
+}
+
+/// Recognizes an unsigned 3 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian u24 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u24;
+///
+/// let be_u24 = |s| {
+///   u24(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_u24 = |s| {
+///   u24(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u24;
+///
+/// let be_u24 = |s| {
+///   u24::<_,(_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_u24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+///
+/// let le_u24 = |s| {
+///   u24::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_u24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn u24<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u24(endian)
+  } else {
+    complete::u24(endian)
+  }
+}
+
+/// Recognizes an unsigned 4 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian u32 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u32;
+///
+/// let be_u32 = |s| {
+///   u32(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_u32 = |s| {
+///   u32(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u32;
+///
+/// let be_u32 = |s| {
+///   u32::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_u32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+///
+/// let le_u32 = |s| {
+///   u32::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_u32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn u32<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, u32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u32(endian)
+  } else {
+    complete::u32(endian)
+  }
+}
+
+/// Recognizes an unsigned 8 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian u64 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u64;
+///
+/// let be_u64 = |s| {
+///   u64(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_u64 = |s| {
+///   u64(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u64;
+///
+/// let be_u64 = |s| {
+///   u64::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_u64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+///
+/// let le_u64 = |s| {
+///   u64::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_u64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn u64<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, u64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u64(endian)
+  } else {
+    complete::u64(endian)
+  }
+}
+
+/// Recognizes an unsigned 16 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian u128 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::u128;
+///
+/// let be_u128 = |s| {
+///   u128(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_u128 = |s| {
+///   u128(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::u128;
+///
+/// let be_u128 = |s| {
+///   u128::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_u128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+///
+/// let le_u128 = |s| {
+///   u128::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_u128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn u128<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, u128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::u128(endian)
+  } else {
+    complete::u128(endian)
+  }
+}
+
+/// Recognizes a signed 1 byte integer
+///
+/// **Note:** that endianness does not apply to 1 byte numbers.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i8;
+///
+/// let parser = |s| {
+///   i8(s)
+/// };
+///
+/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i8;
+///
+/// let parser = |s| {
+///   i8::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i8(input)
+  } else {
+    complete::i8(input)
+  }
+}
+
+/// Recognizes a signed 2 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian i16 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i16;
+///
+/// let be_i16 = |s| {
+///   i16(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_i16 = |s| {
+///   i16(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i16;
+///
+/// let be_i16 = |s| {
+///   i16::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_i16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+///
+/// let le_i16 = |s| {
+///   i16::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_i16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn i16<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, i16, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i16(endian)
+  } else {
+    complete::i16(endian)
+  }
+}
+
+/// Recognizes a signed 3 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian i24 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i24;
+///
+/// let be_i24 = |s| {
+///   i24(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_i24 = |s| {
+///   i24(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i24;
+///
+/// let be_i24 = |s| {
+///   i24::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_i24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+///
+/// let le_i24 = |s| {
+///   i24::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_i24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// ```
+#[inline(always)]
+pub fn i24<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i24(endian)
+  } else {
+    complete::i24(endian)
+  }
+}
+
+/// Recognizes a signed 4 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian i32 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i32;
+///
+/// let be_i32 = |s| {
+///   i32(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_i32 = |s| {
+///   i32(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i32;
+///
+/// let be_i32 = |s| {
+///   i32::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_i32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+///
+/// let le_i32 = |s| {
+///   i32::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_i32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn i32<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, i32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i32(endian)
+  } else {
+    complete::i32(endian)
+  }
+}
+
+/// Recognizes a signed 8 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian i64 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i64;
+///
+/// let be_i64 = |s| {
+///   i64(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_i64 = |s| {
+///   i64(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i64;
+///
+/// let be_i64 = |s| {
+///   i64::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_i64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+///
+/// let le_i64 = |s| {
+///   i64::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_i64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn i64<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, i64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i64(endian)
+  } else {
+    complete::i64(endian)
+  }
+}
+
+/// Recognizes a signed 16 byte integer
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian i128 integer,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::i128;
+///
+/// let be_i128 = |s| {
+///   i128(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+///
+/// let le_i128 = |s| {
+///   i128(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::i128;
+///
+/// let be_i128 = |s| {
+///   i128::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_i128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+///
+/// let le_i128 = |s| {
+///   i128::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_i128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// ```
+#[inline(always)]
+pub fn i128<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, i128, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::i128(endian)
+  } else {
+    complete::i128(endian)
+  }
+}
+
+/// Recognizes a big endian 4 bytes floating point number.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_f32;
+///
+/// let parser = |s| {
+///   be_f32(s)
+/// };
+///
+/// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_f32;
+///
+/// let parser = |s| {
+///   be_f32::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 2.640625)));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn be_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_f32(input)
+  } else {
+    complete::be_f32(input)
+  }
+}
+
+/// Recognizes a big endian 8 bytes floating point number.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::be_f64;
+///
+/// let parser = |s| {
+///   be_f64(s)
+/// };
+///
+/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::be_f64;
+///
+/// let parser = |s| {
+///   be_f64::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn be_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::be_f64(input)
+  } else {
+    complete::be_f64(input)
+  }
+}
+
+/// Recognizes a little endian 4 bytes floating point number.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_f32;
+///
+/// let parser = |s| {
+///   le_f32(s)
+/// };
+///
+/// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_f32;
+///
+/// let parser = |s| {
+///   le_f32::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(3))));
+/// ```
+#[inline(always)]
+pub fn le_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_f32(input)
+  } else {
+    complete::le_f32(input)
+  }
+}
+
+/// Recognizes a little endian 8 bytes floating point number.
+///
+/// *Complete version*: Returns an error if there is not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::le_f64;
+///
+/// let parser = |s| {
+///   le_f64(s)
+/// };
+///
+/// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::le_f64;
+///
+/// let parser = |s| {
+///   le_f64::<_, (_, ErrorKind), true>(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 3145728.0)));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(7))));
+/// ```
+#[inline(always)]
+pub fn le_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::le_f64(input)
+  } else {
+    complete::le_f64(input)
+  }
+}
+
+/// Recognizes a 4 byte floating point number
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian f32 float,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::f32;
+///
+/// let be_f32 = |s| {
+///   f32(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+///
+/// let le_f32 = |s| {
+///   f32(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::f32;
+///
+/// let be_f32 = |s| {
+///   f32::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_f32(Streaming(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(be_f32(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
+///
+/// let le_f32 = |s| {
+///   f32::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_f32(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(le_f32(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, f32, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::f32(endian)
+  } else {
+    complete::f32(endian)
+  }
+}
+
+/// Recognizes an 8 byte floating point number
+///
+/// If the parameter is `nom::number::Endianness::Big`, parse a big endian f64 float,
+/// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
+///
+/// *Complete version*: returns an error if there is not enough input data
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::f64;
+///
+/// let be_f64 = |s| {
+///   f64(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+///
+/// let le_f64 = |s| {
+///   f64(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::f64;
+///
+/// let be_f64 = |s| {
+///   f64::<_, (_, ErrorKind), true>(nom::number::Endianness::Big)(s)
+/// };
+///
+/// assert_eq!(be_f64(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(be_f64(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(5))));
+///
+/// let le_f64 = |s| {
+///   f64::<_, (_, ErrorKind), true>(nom::number::Endianness::Little)(s)
+/// };
+///
+/// assert_eq!(le_f64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Streaming(&b""[..]), 12.5)));
+/// assert_eq!(le_f64(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(5))));
+/// ```
+#[inline(always)]
+pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(
+  endian: crate::number::Endianness,
+) -> fn(I) -> IResult<I, f64, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::f64(endian)
+  } else {
+    complete::f64(endian)
+  }
+}
+
+/// Recognizes a hex-encoded integer.
+///
+/// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::hex_u32;
+///
+/// let parser = |s| {
+///   hex_u32(s)
+/// };
+///
+/// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
+/// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
+/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::hex_u32;
+///
+/// let parser = |s| {
+///   hex_u32(s)
+/// };
+///
+/// assert_eq!(parser(Streaming(&b"01AE;"[..])), Ok((Streaming(&b";"[..]), 0x01AE)));
+/// assert_eq!(parser(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(Err::Error((Streaming(&b"ggg"[..]), ErrorKind::IsA))));
+/// ```
+#[inline(always)]
+pub fn hex_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
+where
+  I: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  <I as InputTakeAtPosition>::Item: AsChar,
+  I: AsBytes,
+  I: InputLength,
+{
+  if STREAMING {
+    streaming::hex_u32(input)
+  } else {
+    complete::hex_u32(input)
+  }
+}
+
+/// Recognizes floating point number in a byte string and returns the corresponding slice.
+///
+/// *Complete version*: Can parse until the end of input.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::recognize_float;
+///
+/// let parser = |s| {
+///   recognize_float(s)
+/// };
+///
+/// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
+/// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
+/// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
+/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::input::Streaming;
+/// use nom::number::recognize_float;
+///
+/// let parser = |s| {
+///   recognize_float(s)
+/// };
+///
+/// assert_eq!(parser(Streaming("11e-1;")), Ok((Streaming(";"), "11e-1")));
+/// assert_eq!(parser(Streaming("123E-02;")), Ok((Streaming(";"), "123E-02")));
+/// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), "123")));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Char))));
+/// ```
+#[inline(always)]
+pub fn recognize_float<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<T, <T as IntoOutput>::Output, E>
+where
+  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  T: Clone + Offset,
+  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputIter>::Item: AsChar,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
+{
+  if STREAMING {
+    streaming::recognize_float(input)
+  } else {
+    complete::recognize_float(input)
+  }
+}
+
+/// Recognizes a floating point number in text format
+///
+/// It returns a tuple of (`sign`, `integer part`, `fraction part` and `exponent`) of the input
+/// data.
+///
+/// *Complete version*: Can parse until the end of input.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+#[inline(always)]
+pub fn recognize_float_parts<T, E: ParseError<T>, const STREAMING: bool>(
+  input: T,
+) -> IResult<
+  T,
+  (
+    bool,
+    <T as IntoOutput>::Output,
+    <T as IntoOutput>::Output,
+    i32,
+  ),
+  E,
+>
+where
+  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  T: Clone + Offset,
+  T: InputIter + InputTake + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as InputIter>::Item: AsChar + Copy,
+  T: InputTakeAtPosition + InputLength,
+  <T as InputTakeAtPosition>::Item: AsChar,
+  T: for<'a> Compare<&'a [u8]>,
+  T: AsBytes,
+{
+  if STREAMING {
+    streaming::recognize_float_parts(input)
+  } else {
+    complete::recognize_float_parts(input)
+  }
+}
+
+/// Recognizes floating point number in text format and returns a f32.
+///
+/// *Complete version*: Can parse until the end of input.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::float;
+///
+/// let parser = |s| {
+///   float(s)
+/// };
+///
+/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::float;
+///
+/// let parser = |s| {
+///   float(s)
+/// };
+///
+/// assert_eq!(parser(Streaming("11e-1 ")), Ok((Streaming(" "), 1.1)));
+/// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Float))));
+/// ```
+#[inline(always)]
+pub fn float<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f32, E>
+where
+  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  T: Clone + Offset + Compare<&'static str>,
+  T: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as IntoOutput>::Output: ParseTo<f32>,
+  <T as InputIter>::Item: AsChar + Copy,
+  <T as InputIter>::IterElem: Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
+  T: AsBytes,
+  T: for<'a> Compare<&'a [u8]>,
+{
+  if STREAMING {
+    streaming::float(input)
+  } else {
+    complete::float(input)
+  }
+}
+
+/// Recognizes floating point number in text format and returns a f64.
+///
+/// *Complete version*: Can parse until the end of input.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
+///
+/// # Example
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// use nom::number::double;
+///
+/// let parser = |s| {
+///   double(s)
+/// };
+///
+/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```
+///
+/// ```rust
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::Needed::Size;
+/// # use nom::input::Streaming;
+/// use nom::number::double;
+///
+/// let parser = |s| {
+///   double(s)
+/// };
+///
+/// assert_eq!(parser(Streaming("11e-1 ")), Ok((Streaming(" "), 1.1)));
+/// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Float))));
+/// ```
+#[inline(always)]
+pub fn double<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f64, E>
+where
+  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  T: Clone + Offset + Compare<&'static str>,
+  T: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  T: IntoOutput,
+  <T as IntoOutput>::Output: ParseTo<f64>,
+  <T as InputIter>::Item: AsChar + Copy,
+  <T as InputIter>::IterElem: Clone,
+  T: InputTakeAtPosition,
+  <T as InputTakeAtPosition>::Item: AsChar,
+  T: AsBytes,
+  T: for<'a> Compare<&'a [u8]>,
+{
+  if STREAMING {
+    streaming::double(input)
+  } else {
+    complete::double(input)
+  }
 }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1,5 +1,7 @@
 //! Parsers recognizing numbers, streaming version
 
+#![allow(deprecated)]
+
 use crate::branch::alt;
 use crate::bytes::streaming::tag;
 use crate::character::streaming::{char, digit1, sign};
@@ -28,6 +30,12 @@ use crate::*;
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u8`][crate::number::be_u8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -58,6 +66,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u16`][crate::number::be_u16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -91,6 +105,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u24`][crate::number::be_u24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -124,6 +144,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u32`][crate::number::be_u32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -157,6 +183,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u64`][crate::number::be_u64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -189,6 +221,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_u128`][crate::number::be_u128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_u128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -219,6 +257,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i8`][crate::number::be_i8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -239,6 +283,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i16`][crate::number::be_i16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -259,6 +309,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i24`][crate::number::be_i24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -288,6 +344,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i32`][crate::number::be_i32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -309,6 +371,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i64`][crate::number::be_i64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -329,6 +397,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_i128`][crate::number::be_i128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_i128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -349,6 +423,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u8`][crate::number::le_u8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -379,6 +459,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u16`][crate::number::le_u16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -412,6 +498,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u24`][crate::number::le_u24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -445,6 +537,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u32`][crate::number::le_u32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -478,6 +576,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u64`][crate::number::le_u64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -511,6 +615,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_u128`][crate::number::le_u128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_u128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -541,6 +651,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i8`][crate::number::le_i8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -564,6 +680,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i16`][crate::number::le_i16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -587,6 +709,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i24`][crate::number::le_i24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -619,6 +747,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i32`][crate::number::le_i32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -642,6 +776,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i64`][crate::number::le_i64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -665,6 +805,12 @@ where
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_i128`][crate::number::le_i128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_i128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -689,6 +835,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u8`][crate::number::u8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -729,6 +881,12 @@ where
 /// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u16`][crate::number::u16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -768,6 +926,12 @@ where
 /// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u24`][crate::number::u24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -807,6 +971,12 @@ where
 /// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u32`][crate::number::u32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -846,6 +1016,12 @@ where
 /// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u64`][crate::number::u64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -885,6 +1061,12 @@ where
 /// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::u128`][crate::number::u128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::u128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -916,6 +1098,12 @@ where
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i8`][crate::number::i8] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i8` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -948,6 +1136,12 @@ where
 /// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i16`][crate::number::i16] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i16` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -987,6 +1181,12 @@ where
 /// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i24`][crate::number::i24] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i24` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1026,6 +1226,12 @@ where
 /// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i32`][crate::number::i32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1065,6 +1271,12 @@ where
 /// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i64`][crate::number::i64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1104,6 +1316,12 @@ where
 /// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::i128`][crate::number::i128] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::i128` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1133,6 +1351,12 @@ where
 /// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_f32`][crate::number::be_f32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_f32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1158,6 +1382,12 @@ where
 /// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::be_f64`][crate::number::be_f64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::be_f64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1183,6 +1413,12 @@ where
 /// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_f32`][crate::number::le_f32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_f32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1208,6 +1444,12 @@ where
 /// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::le_f64`][crate::number::le_f64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::le_f64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1243,6 +1485,12 @@ where
 /// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::f32`][crate::number::f32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::f32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1282,6 +1530,12 @@ where
 /// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::f64`][crate::number::f64] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::f64` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
@@ -1312,6 +1566,12 @@ where
 /// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::hex_u32`][crate::number::hex_u32] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::hex_u32` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: InputTakeAtPosition,
@@ -1368,6 +1628,9 @@ where
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float`][crate::number::recognize_float] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::number::recognize_float` with input wrapped in `nom::input::Streaming`")]
 pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -1396,6 +1659,12 @@ where
 
 // workaround until issues with minimal-lexical are fixed
 #[doc(hidden)]
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float_or_exceptions`][crate::number::recognize_float_or_exceptions] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::recognize_float_or_exceptions` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn recognize_float_or_exceptions<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
@@ -1438,6 +1707,12 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::recognize_float_parts`][crate::number::recognize_float_parts] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::recognize_float_parts` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn recognize_float_parts<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<
@@ -1562,6 +1837,12 @@ where
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::float`][crate::number::float] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::float` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
@@ -1620,6 +1901,12 @@ where
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
 /// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`nom::number::double`][crate::number::double] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `nom::number::double` with input wrapped in `nom::input::Streaming`"
+)]
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1438,7 +1438,18 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-pub fn recognize_float_parts<T, E: ParseError<T>>(input: T) -> IResult<T, (bool, T, T, i32), E>
+pub fn recognize_float_parts<T, E: ParseError<T>>(
+  input: T,
+) -> IResult<
+  T,
+  (
+    bool,
+    <T as IntoOutput>::Output,
+    <T as IntoOutput>::Output,
+    i32,
+  ),
+  E,
+>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
@@ -1527,7 +1538,10 @@ where
     (i2, 0)
   };
 
-  Ok((i, (sign, integer, fraction, exp)))
+  Ok((
+    i,
+    (sign, integer.into_output(), fraction.into_output(), exp),
+  ))
 }
 
 /// Recognizes floating point number in text format and returns a f32.

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -1,0 +1,1275 @@
+use super::*;
+
+mod complete {
+  use super::*;
+  use crate::error::ErrorKind;
+  use crate::Err;
+  use proptest::prelude::*;
+
+  macro_rules! assert_parse(
+    ($left: expr, $right: expr) => {
+      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      assert_eq!(res, $right);
+    };
+  );
+
+  #[test]
+  fn i8_tests() {
+    assert_parse!(i8(&[0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(i8(&[0x7f][..]), Ok((&b""[..], 127)));
+    assert_parse!(i8(&[0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(i8(&[0x80][..]), Ok((&b""[..], -128)));
+  }
+
+  #[test]
+  fn be_i8_tests() {
+    assert_parse!(be_i8(&[0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(be_i8(&[0x7f][..]), Ok((&b""[..], 127)));
+    assert_parse!(be_i8(&[0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(be_i8(&[0x80][..]), Ok((&b""[..], -128)));
+  }
+
+  #[test]
+  fn be_i16_tests() {
+    assert_parse!(be_i16(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(be_i16(&[0x7f, 0xff][..]), Ok((&b""[..], 32_767_i16)));
+    assert_parse!(be_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(be_i16(&[0x80, 0x00][..]), Ok((&b""[..], -32_768_i16)));
+  }
+
+  #[test]
+  fn be_u24_tests() {
+    assert_parse!(be_u24(&[0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(be_u24(&[0x00, 0xFF, 0xFF][..]), Ok((&b""[..], 65_535_u32)));
+    assert_parse!(
+      be_u24(&[0x12, 0x34, 0x56][..]),
+      Ok((&b""[..], 1_193_046_u32))
+    );
+  }
+
+  #[test]
+  fn be_i24_tests() {
+    assert_parse!(be_i24(&[0xFF, 0xFF, 0xFF][..]), Ok((&b""[..], -1_i32)));
+    assert_parse!(be_i24(&[0xFF, 0x00, 0x00][..]), Ok((&b""[..], -65_536_i32)));
+    assert_parse!(
+      be_i24(&[0xED, 0xCB, 0xAA][..]),
+      Ok((&b""[..], -1_193_046_i32))
+    );
+  }
+
+  #[test]
+  fn be_i32_tests() {
+    assert_parse!(be_i32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(
+      be_i32(&[0x7f, 0xff, 0xff, 0xff][..]),
+      Ok((&b""[..], 2_147_483_647_i32))
+    );
+    assert_parse!(be_i32(&[0xff, 0xff, 0xff, 0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(
+      be_i32(&[0x80, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], -2_147_483_648_i32))
+    );
+  }
+
+  #[test]
+  fn be_i64_tests() {
+    assert_parse!(
+      be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 0))
+    );
+    assert_parse!(
+      be_i64(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+      Ok((&b""[..], 9_223_372_036_854_775_807_i64))
+    );
+    assert_parse!(
+      be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+      Ok((&b""[..], -1))
+    );
+    assert_parse!(
+      be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], -9_223_372_036_854_775_808_i64))
+    );
+  }
+
+  #[test]
+  fn be_i128_tests() {
+    assert_parse!(
+      be_i128(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      ),
+      Ok((&b""[..], 0))
+    );
+    assert_parse!(
+      be_i128(
+        &[
+          0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      ),
+      Ok((
+        &b""[..],
+        170_141_183_460_469_231_731_687_303_715_884_105_727_i128
+      ))
+    );
+    assert_parse!(
+      be_i128(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      ),
+      Ok((&b""[..], -1))
+    );
+    assert_parse!(
+      be_i128(
+        &[
+          0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      ),
+      Ok((
+        &b""[..],
+        -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
+      ))
+    );
+  }
+
+  #[test]
+  fn le_i8_tests() {
+    assert_parse!(le_i8(&[0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(le_i8(&[0x7f][..]), Ok((&b""[..], 127)));
+    assert_parse!(le_i8(&[0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(le_i8(&[0x80][..]), Ok((&b""[..], -128)));
+  }
+
+  #[test]
+  fn le_i16_tests() {
+    assert_parse!(le_i16(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(le_i16(&[0xff, 0x7f][..]), Ok((&b""[..], 32_767_i16)));
+    assert_parse!(le_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(le_i16(&[0x00, 0x80][..]), Ok((&b""[..], -32_768_i16)));
+  }
+
+  #[test]
+  fn le_u24_tests() {
+    assert_parse!(le_u24(&[0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(le_u24(&[0xFF, 0xFF, 0x00][..]), Ok((&b""[..], 65_535_u32)));
+    assert_parse!(
+      le_u24(&[0x56, 0x34, 0x12][..]),
+      Ok((&b""[..], 1_193_046_u32))
+    );
+  }
+
+  #[test]
+  fn le_i24_tests() {
+    assert_parse!(le_i24(&[0xFF, 0xFF, 0xFF][..]), Ok((&b""[..], -1_i32)));
+    assert_parse!(le_i24(&[0x00, 0x00, 0xFF][..]), Ok((&b""[..], -65_536_i32)));
+    assert_parse!(
+      le_i24(&[0xAA, 0xCB, 0xED][..]),
+      Ok((&b""[..], -1_193_046_i32))
+    );
+  }
+
+  #[test]
+  fn le_i32_tests() {
+    assert_parse!(le_i32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
+    assert_parse!(
+      le_i32(&[0xff, 0xff, 0xff, 0x7f][..]),
+      Ok((&b""[..], 2_147_483_647_i32))
+    );
+    assert_parse!(le_i32(&[0xff, 0xff, 0xff, 0xff][..]), Ok((&b""[..], -1)));
+    assert_parse!(
+      le_i32(&[0x00, 0x00, 0x00, 0x80][..]),
+      Ok((&b""[..], -2_147_483_648_i32))
+    );
+  }
+
+  #[test]
+  fn le_i64_tests() {
+    assert_parse!(
+      le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 0))
+    );
+    assert_parse!(
+      le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]),
+      Ok((&b""[..], 9_223_372_036_854_775_807_i64))
+    );
+    assert_parse!(
+      le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+      Ok((&b""[..], -1))
+    );
+    assert_parse!(
+      le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]),
+      Ok((&b""[..], -9_223_372_036_854_775_808_i64))
+    );
+  }
+
+  #[test]
+  fn le_i128_tests() {
+    assert_parse!(
+      le_i128(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      ),
+      Ok((&b""[..], 0))
+    );
+    assert_parse!(
+      le_i128(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0x7f
+        ][..]
+      ),
+      Ok((
+        &b""[..],
+        170_141_183_460_469_231_731_687_303_715_884_105_727_i128
+      ))
+    );
+    assert_parse!(
+      le_i128(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      ),
+      Ok((&b""[..], -1))
+    );
+    assert_parse!(
+      le_i128(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x80
+        ][..]
+      ),
+      Ok((
+        &b""[..],
+        -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
+      ))
+    );
+  }
+
+  #[test]
+  fn be_f32_tests() {
+    assert_parse!(be_f32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0_f32)));
+    assert_parse!(
+      be_f32(&[0x4d, 0x31, 0x1f, 0xd8][..]),
+      Ok((&b""[..], 185_728_392_f32))
+    );
+  }
+
+  #[test]
+  fn be_f64_tests() {
+    assert_parse!(
+      be_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 0_f64))
+    );
+    assert_parse!(
+      be_f64(&[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 185_728_392_f64))
+    );
+  }
+
+  #[test]
+  fn le_f32_tests() {
+    assert_parse!(le_f32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0_f32)));
+    assert_parse!(
+      le_f32(&[0xd8, 0x1f, 0x31, 0x4d][..]),
+      Ok((&b""[..], 185_728_392_f32))
+    );
+  }
+
+  #[test]
+  fn le_f64_tests() {
+    assert_parse!(
+      le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 0_f64))
+    );
+    assert_parse!(
+      le_f64(&[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]),
+      Ok((&b""[..], 185_728_392_f64))
+    );
+  }
+
+  #[test]
+  fn hex_u32_tests() {
+    assert_parse!(
+      hex_u32(&b";"[..]),
+      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+    );
+    assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
+    assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
+    assert_parse!(hex_u32(&b"c5a31be2;"[..]), Ok((&b";"[..], 3_315_801_058)));
+    assert_parse!(hex_u32(&b"C5A31be2;"[..]), Ok((&b";"[..], 3_315_801_058)));
+    assert_parse!(hex_u32(&b"00c5a31be2;"[..]), Ok((&b"e2;"[..], 12_952_347)));
+    assert_parse!(
+      hex_u32(&b"c5a31be201;"[..]),
+      Ok((&b"01;"[..], 3_315_801_058))
+    );
+    assert_parse!(hex_u32(&b"ffffffff;"[..]), Ok((&b";"[..], 4_294_967_295)));
+    assert_parse!(hex_u32(&b"0x1be2;"[..]), Ok((&b"x1be2;"[..], 0)));
+    assert_parse!(hex_u32(&b"12af"[..]), Ok((&b""[..], 0x12af)));
+  }
+
+  #[test]
+  #[cfg(feature = "std")]
+  fn float_test() {
+    let mut test_cases = vec![
+      "+3.14",
+      "3.14",
+      "-3.14",
+      "0",
+      "0.0",
+      "1.",
+      ".789",
+      "-.5",
+      "1e7",
+      "-1E-7",
+      ".3e-2",
+      "1.e4",
+      "1.2e4",
+      "12.34",
+      "-1.234E-12",
+      "-1.234e-12",
+      "0.00000000000000000087",
+    ];
+
+    for test in test_cases.drain(..) {
+      let expected32 = str::parse::<f32>(test).unwrap();
+      let expected64 = str::parse::<f64>(test).unwrap();
+
+      println!("now parsing: {} -> {}", test, expected32);
+
+      let larger = format!("{}", test);
+      assert_parse!(recognize_float(&larger[..]), Ok(("", test)));
+
+      assert_parse!(float(larger.as_bytes()), Ok((&b""[..], expected32)));
+      assert_parse!(float(&larger[..]), Ok(("", expected32)));
+
+      assert_parse!(double(larger.as_bytes()), Ok((&b""[..], expected64)));
+      assert_parse!(double(&larger[..]), Ok(("", expected64)));
+    }
+
+    let remaining_exponent = "-1.234E-";
+    assert_parse!(
+      recognize_float(remaining_exponent),
+      Err(Err::Failure(("", ErrorKind::Digit)))
+    );
+
+    let (_i, nan) = float::<_, (), false>("NaN").unwrap();
+    assert!(nan.is_nan());
+
+    let (_i, inf) = float::<_, (), false>("inf").unwrap();
+    assert!(inf.is_infinite());
+    let (_i, inf) = float::<_, (), false>("infinite").unwrap();
+    assert!(inf.is_infinite());
+  }
+
+  #[test]
+  fn configurable_endianness() {
+    use crate::number::Endianness;
+
+    fn be_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+      u16(Endianness::Big)(i)
+    }
+    fn le_tst16(i: &[u8]) -> IResult<&[u8], u16> {
+      u16(Endianness::Little)(i)
+    }
+    assert_eq!(be_tst16(&[0x80, 0x00]), Ok((&b""[..], 32_768_u16)));
+    assert_eq!(le_tst16(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
+
+    fn be_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+      u32(Endianness::Big)(i)
+    }
+    fn le_tst32(i: &[u8]) -> IResult<&[u8], u32> {
+      u32(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tst32(&[0x12, 0x00, 0x60, 0x00]),
+      Ok((&b""[..], 302_014_464_u32))
+    );
+    assert_eq!(
+      le_tst32(&[0x12, 0x00, 0x60, 0x00]),
+      Ok((&b""[..], 6_291_474_u32))
+    );
+
+    fn be_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+      u64(Endianness::Big)(i)
+    }
+    fn le_tst64(i: &[u8]) -> IResult<&[u8], u64> {
+      u64(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tst64(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+      Ok((&b""[..], 1_297_142_246_100_992_000_u64))
+    );
+    assert_eq!(
+      le_tst64(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+      Ok((&b""[..], 36_028_874_334_666_770_u64))
+    );
+
+    fn be_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+      i16(Endianness::Big)(i)
+    }
+    fn le_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
+      i16(Endianness::Little)(i)
+    }
+    assert_eq!(be_tsti16(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
+    assert_eq!(le_tsti16(&[0x00, 0x80]), Ok((&b""[..], -32_768_i16)));
+
+    fn be_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+      i32(Endianness::Big)(i)
+    }
+    fn le_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
+      i32(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tsti32(&[0x00, 0x12, 0x60, 0x00]),
+      Ok((&b""[..], 1_204_224_i32))
+    );
+    assert_eq!(
+      le_tsti32(&[0x00, 0x12, 0x60, 0x00]),
+      Ok((&b""[..], 6_296_064_i32))
+    );
+
+    fn be_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+      i64(Endianness::Big)(i)
+    }
+    fn le_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
+      i64(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tsti64(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+      Ok((&b""[..], 71_881_672_479_506_432_i64))
+    );
+    assert_eq!(
+      le_tsti64(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+      Ok((&b""[..], 36_028_874_334_732_032_i64))
+    );
+  }
+
+  #[cfg(feature = "std")]
+  fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
+    match crate::number::complete::recognize_float_or_exceptions(i) {
+      Err(e) => Err(e),
+      Ok((i, s)) => {
+        if s.is_empty() {
+          return Err(Err::Error(()));
+        }
+        match s.parse_to() {
+          Some(n) => Ok((i, n)),
+          None => Err(Err::Error(())),
+        }
+      }
+    }
+  }
+
+  proptest! {
+    #[test]
+    #[cfg(feature = "std")]
+    fn floats(s in "\\PC*") {
+        println!("testing {}", s);
+        let res1 = parse_f64(&s);
+        let res2 = double::<_, (), false>(s.as_str());
+        assert_eq!(res1, res2);
+    }
+  }
+}
+
+mod streaming {
+  use super::*;
+  use crate::error::ErrorKind;
+  use crate::input::Streaming;
+  use crate::{Err, Needed};
+  use proptest::prelude::*;
+
+  macro_rules! assert_parse(
+    ($left: expr, $right: expr) => {
+      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      assert_eq!(res, $right);
+    };
+  );
+
+  #[test]
+  fn i8_tests() {
+    assert_parse!(be_i8(Streaming(&[0x00][..])), Ok((Streaming(&b""[..]), 0)));
+    assert_parse!(
+      be_i8(Streaming(&[0x7f][..])),
+      Ok((Streaming(&b""[..]), 127))
+    );
+    assert_parse!(be_i8(Streaming(&[0xff][..])), Ok((Streaming(&b""[..]), -1)));
+    assert_parse!(
+      be_i8(Streaming(&[0x80][..])),
+      Ok((Streaming(&b""[..]), -128))
+    );
+    assert_parse!(
+      be_i8(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn i16_tests() {
+    assert_parse!(
+      be_i16(Streaming(&[0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      be_i16(Streaming(&[0x7f, 0xff][..])),
+      Ok((Streaming(&b""[..]), 32_767_i16))
+    );
+    assert_parse!(
+      be_i16(Streaming(&[0xff, 0xff][..])),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      be_i16(Streaming(&[0x80, 0x00][..])),
+      Ok((Streaming(&b""[..]), -32_768_i16))
+    );
+    assert_parse!(
+      be_i16(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_i16(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn u24_tests() {
+    assert_parse!(
+      be_u24(Streaming(&[0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      be_u24(Streaming(&[0x00, 0xFF, 0xFF][..])),
+      Ok((Streaming(&b""[..]), 65_535_u32))
+    );
+    assert_parse!(
+      be_u24(Streaming(&[0x12, 0x34, 0x56][..])),
+      Ok((Streaming(&b""[..]), 1_193_046_u32))
+    );
+    assert_parse!(
+      be_u24(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(3)))
+    );
+    assert_parse!(
+      be_u24(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_u24(Streaming(&[0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn i24_tests() {
+    assert_parse!(
+      be_i24(Streaming(&[0xFF, 0xFF, 0xFF][..])),
+      Ok((Streaming(&b""[..]), -1_i32))
+    );
+    assert_parse!(
+      be_i24(Streaming(&[0xFF, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), -65_536_i32))
+    );
+    assert_parse!(
+      be_i24(Streaming(&[0xED, 0xCB, 0xAA][..])),
+      Ok((Streaming(&b""[..]), -1_193_046_i32))
+    );
+    assert_parse!(
+      be_i24(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(3)))
+    );
+    assert_parse!(
+      be_i24(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_i24(Streaming(&[0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn i32_tests() {
+    assert_parse!(
+      be_i32(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0x7f, 0xff, 0xff, 0xff][..])),
+      Ok((Streaming(&b""[..]), 2_147_483_647_i32))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0xff, 0xff, 0xff, 0xff][..])),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0x80, 0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), -2_147_483_648_i32))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(4)))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(3)))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_i32(Streaming(&[0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn i64_tests() {
+    assert_parse!(
+      be_i64(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      be_i64(Streaming(
+        &[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
+      )),
+      Ok((Streaming(&b""[..]), 9_223_372_036_854_775_807_i64))
+    );
+    assert_parse!(
+      be_i64(Streaming(
+        &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
+      )),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      be_i64(Streaming(
+        &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), -9_223_372_036_854_775_808_i64))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(8)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(7)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(6)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(5)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(4)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(3)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn i128_tests() {
+    assert_parse!(
+      be_i128(Streaming(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      )),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[
+          0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      )),
+      Ok((
+        Streaming(&b""[..]),
+        170_141_183_460_469_231_731_687_303_715_884_105_727_i128
+      ))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      )),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[
+          0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      )),
+      Ok((
+        Streaming(&b""[..]),
+        -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
+      ))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[][..])),
+      Err(Err::Incomplete(Needed::new(16)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00][..])),
+      Err(Err::Incomplete(Needed::new(15)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(14)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(13)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(12)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(11)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(10)))
+    );
+    assert_parse!(
+      be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+      Err(Err::Incomplete(Needed::new(9)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(8)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(7)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(6)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(5)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(4)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(3)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+    assert_parse!(
+      be_i128(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+          [..]
+      )),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn le_i8_tests() {
+    assert_parse!(le_i8(Streaming(&[0x00][..])), Ok((Streaming(&b""[..]), 0)));
+    assert_parse!(
+      le_i8(Streaming(&[0x7f][..])),
+      Ok((Streaming(&b""[..]), 127))
+    );
+    assert_parse!(le_i8(Streaming(&[0xff][..])), Ok((Streaming(&b""[..]), -1)));
+    assert_parse!(
+      le_i8(Streaming(&[0x80][..])),
+      Ok((Streaming(&b""[..]), -128))
+    );
+  }
+
+  #[test]
+  fn le_i16_tests() {
+    assert_parse!(
+      le_i16(Streaming(&[0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      le_i16(Streaming(&[0xff, 0x7f][..])),
+      Ok((Streaming(&b""[..]), 32_767_i16))
+    );
+    assert_parse!(
+      le_i16(Streaming(&[0xff, 0xff][..])),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      le_i16(Streaming(&[0x00, 0x80][..])),
+      Ok((Streaming(&b""[..]), -32_768_i16))
+    );
+  }
+
+  #[test]
+  fn le_u24_tests() {
+    assert_parse!(
+      le_u24(Streaming(&[0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      le_u24(Streaming(&[0xFF, 0xFF, 0x00][..])),
+      Ok((Streaming(&b""[..]), 65_535_u32))
+    );
+    assert_parse!(
+      le_u24(Streaming(&[0x56, 0x34, 0x12][..])),
+      Ok((Streaming(&b""[..]), 1_193_046_u32))
+    );
+  }
+
+  #[test]
+  fn le_i24_tests() {
+    assert_parse!(
+      le_i24(Streaming(&[0xFF, 0xFF, 0xFF][..])),
+      Ok((Streaming(&b""[..]), -1_i32))
+    );
+    assert_parse!(
+      le_i24(Streaming(&[0x00, 0x00, 0xFF][..])),
+      Ok((Streaming(&b""[..]), -65_536_i32))
+    );
+    assert_parse!(
+      le_i24(Streaming(&[0xAA, 0xCB, 0xED][..])),
+      Ok((Streaming(&b""[..]), -1_193_046_i32))
+    );
+  }
+
+  #[test]
+  fn le_i32_tests() {
+    assert_parse!(
+      le_i32(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      le_i32(Streaming(&[0xff, 0xff, 0xff, 0x7f][..])),
+      Ok((Streaming(&b""[..]), 2_147_483_647_i32))
+    );
+    assert_parse!(
+      le_i32(Streaming(&[0xff, 0xff, 0xff, 0xff][..])),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      le_i32(Streaming(&[0x00, 0x00, 0x00, 0x80][..])),
+      Ok((Streaming(&b""[..]), -2_147_483_648_i32))
+    );
+  }
+
+  #[test]
+  fn le_i64_tests() {
+    assert_parse!(
+      le_i64(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      le_i64(Streaming(
+        &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]
+      )),
+      Ok((Streaming(&b""[..]), 9_223_372_036_854_775_807_i64))
+    );
+    assert_parse!(
+      le_i64(Streaming(
+        &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
+      )),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      le_i64(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]
+      )),
+      Ok((Streaming(&b""[..]), -9_223_372_036_854_775_808_i64))
+    );
+  }
+
+  #[test]
+  fn le_i128_tests() {
+    assert_parse!(
+      le_i128(Streaming(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00
+        ][..]
+      )),
+      Ok((Streaming(&b""[..]), 0))
+    );
+    assert_parse!(
+      le_i128(Streaming(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0x7f
+        ][..]
+      )),
+      Ok((
+        Streaming(&b""[..]),
+        170_141_183_460_469_231_731_687_303_715_884_105_727_i128
+      ))
+    );
+    assert_parse!(
+      le_i128(Streaming(
+        &[
+          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+          0xff
+        ][..]
+      )),
+      Ok((Streaming(&b""[..]), -1))
+    );
+    assert_parse!(
+      le_i128(Streaming(
+        &[
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x80
+        ][..]
+      )),
+      Ok((
+        Streaming(&b""[..]),
+        -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
+      ))
+    );
+  }
+
+  #[test]
+  fn be_f32_tests() {
+    assert_parse!(
+      be_f32(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0_f32))
+    );
+    assert_parse!(
+      be_f32(Streaming(&[0x4d, 0x31, 0x1f, 0xd8][..])),
+      Ok((Streaming(&b""[..]), 185_728_392_f32))
+    );
+  }
+
+  #[test]
+  fn be_f64_tests() {
+    assert_parse!(
+      be_f64(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), 0_f64))
+    );
+    assert_parse!(
+      be_f64(Streaming(
+        &[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), 185_728_392_f64))
+    );
+  }
+
+  #[test]
+  fn le_f32_tests() {
+    assert_parse!(
+      le_f32(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
+      Ok((Streaming(&b""[..]), 0_f32))
+    );
+    assert_parse!(
+      le_f32(Streaming(&[0xd8, 0x1f, 0x31, 0x4d][..])),
+      Ok((Streaming(&b""[..]), 185_728_392_f32))
+    );
+  }
+
+  #[test]
+  fn le_f64_tests() {
+    assert_parse!(
+      le_f64(Streaming(
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+      )),
+      Ok((Streaming(&b""[..]), 0_f64))
+    );
+    assert_parse!(
+      le_f64(Streaming(
+        &[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]
+      )),
+      Ok((Streaming(&b""[..]), 185_728_392_f64))
+    );
+  }
+
+  #[test]
+  fn hex_u32_tests() {
+    assert_parse!(
+      hex_u32(Streaming(&b";"[..])),
+      Err(Err::Error(error_position!(
+        Streaming(&b";"[..]),
+        ErrorKind::IsA
+      )))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"ff;"[..])),
+      Ok((Streaming(&b";"[..]), 255))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"1be2;"[..])),
+      Ok((Streaming(&b";"[..]), 7138))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"c5a31be2;"[..])),
+      Ok((Streaming(&b";"[..]), 3_315_801_058))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"C5A31be2;"[..])),
+      Ok((Streaming(&b";"[..]), 3_315_801_058))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"00c5a31be2;"[..])),
+      Ok((Streaming(&b"e2;"[..]), 12_952_347))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"c5a31be201;"[..])),
+      Ok((Streaming(&b"01;"[..]), 3_315_801_058))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"ffffffff;"[..])),
+      Ok((Streaming(&b";"[..]), 4_294_967_295))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"0x1be2;"[..])),
+      Ok((Streaming(&b"x1be2;"[..]), 0))
+    );
+    assert_parse!(
+      hex_u32(Streaming(&b"12af"[..])),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  #[cfg(feature = "std")]
+  fn float_test() {
+    let mut test_cases = vec![
+      "+3.14",
+      "3.14",
+      "-3.14",
+      "0",
+      "0.0",
+      "1.",
+      ".789",
+      "-.5",
+      "1e7",
+      "-1E-7",
+      ".3e-2",
+      "1.e4",
+      "1.2e4",
+      "12.34",
+      "-1.234E-12",
+      "-1.234e-12",
+      "0.00000000000000000087",
+    ];
+
+    for test in test_cases.drain(..) {
+      let expected32 = str::parse::<f32>(test).unwrap();
+      let expected64 = str::parse::<f64>(test).unwrap();
+
+      println!("now parsing: {} -> {}", test, expected32);
+
+      let larger = format!("{};", test);
+      assert_parse!(
+        recognize_float(Streaming(&larger[..])),
+        Ok((Streaming(";"), test))
+      );
+
+      assert_parse!(
+        float(Streaming(larger.as_bytes())),
+        Ok((Streaming(&b";"[..]), expected32))
+      );
+      assert_parse!(
+        float(Streaming(&larger[..])),
+        Ok((Streaming(";"), expected32))
+      );
+
+      assert_parse!(
+        double(Streaming(larger.as_bytes())),
+        Ok((Streaming(&b";"[..]), expected64))
+      );
+      assert_parse!(
+        double(Streaming(&larger[..])),
+        Ok((Streaming(";"), expected64))
+      );
+    }
+
+    let remaining_exponent = "-1.234E-";
+    assert_parse!(
+      recognize_float(Streaming(remaining_exponent)),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+
+    let (_i, nan) = float::<_, (), true>(Streaming("NaN")).unwrap();
+    assert!(nan.is_nan());
+
+    let (_i, inf) = float::<_, (), true>(Streaming("inf")).unwrap();
+    assert!(inf.is_infinite());
+    let (_i, inf) = float::<_, (), true>(Streaming("infinite")).unwrap();
+    assert!(inf.is_infinite());
+  }
+
+  #[test]
+  fn configurable_endianness() {
+    use crate::number::Endianness;
+
+    fn be_tst16(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u16> {
+      u16(Endianness::Big)(i)
+    }
+    fn le_tst16(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u16> {
+      u16(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tst16(Streaming(&[0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 32_768_u16))
+    );
+    assert_eq!(
+      le_tst16(Streaming(&[0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 128_u16))
+    );
+
+    fn be_tst32(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
+      u32(Endianness::Big)(i)
+    }
+    fn le_tst32(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
+      u32(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tst32(Streaming(&[0x12, 0x00, 0x60, 0x00])),
+      Ok((Streaming(&b""[..]), 302_014_464_u32))
+    );
+    assert_eq!(
+      le_tst32(Streaming(&[0x12, 0x00, 0x60, 0x00])),
+      Ok((Streaming(&b""[..]), 6_291_474_u32))
+    );
+
+    fn be_tst64(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u64> {
+      u64(Endianness::Big)(i)
+    }
+    fn le_tst64(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u64> {
+      u64(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tst64(Streaming(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 1_297_142_246_100_992_000_u64))
+    );
+    assert_eq!(
+      le_tst64(Streaming(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 36_028_874_334_666_770_u64))
+    );
+
+    fn be_tsti16(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i16> {
+      i16(Endianness::Big)(i)
+    }
+    fn le_tsti16(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i16> {
+      i16(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tsti16(Streaming(&[0x00, 0x80])),
+      Ok((Streaming(&b""[..]), 128_i16))
+    );
+    assert_eq!(
+      le_tsti16(Streaming(&[0x00, 0x80])),
+      Ok((Streaming(&b""[..]), -32_768_i16))
+    );
+
+    fn be_tsti32(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i32> {
+      i32(Endianness::Big)(i)
+    }
+    fn le_tsti32(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i32> {
+      i32(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tsti32(Streaming(&[0x00, 0x12, 0x60, 0x00])),
+      Ok((Streaming(&b""[..]), 1_204_224_i32))
+    );
+    assert_eq!(
+      le_tsti32(Streaming(&[0x00, 0x12, 0x60, 0x00])),
+      Ok((Streaming(&b""[..]), 6_296_064_i32))
+    );
+
+    fn be_tsti64(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i64> {
+      i64(Endianness::Big)(i)
+    }
+    fn le_tsti64(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i64> {
+      i64(Endianness::Little)(i)
+    }
+    assert_eq!(
+      be_tsti64(Streaming(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 71_881_672_479_506_432_i64))
+    );
+    assert_eq!(
+      le_tsti64(Streaming(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
+      Ok((Streaming(&b""[..]), 36_028_874_334_732_032_i64))
+    );
+  }
+
+  #[cfg(feature = "std")]
+  fn parse_f64(i: Streaming<&str>) -> IResult<Streaming<&str>, f64, ()> {
+    match crate::number::streaming::recognize_float_or_exceptions(i) {
+      Err(e) => Err(e),
+      Ok((i, s)) => {
+        if s.is_empty() {
+          return Err(Err::Error(()));
+        }
+        match s.parse_to() {
+          Some(n) => Ok((i, n)),
+          None => Err(Err::Error(())),
+        }
+      }
+    }
+  }
+
+  proptest! {
+    #[test]
+    #[cfg(feature = "std")]
+    fn floats(s in "\\PC*") {
+        println!("testing {}", s);
+        let res1 = parse_f64(Streaming(&s));
+        let res2 = double::<_, (), true>(Streaming(s.as_str()));
+        assert_eq!(res1, res2);
+    }
+  }
+}

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -454,6 +454,7 @@ mod complete {
 
   #[cfg(feature = "std")]
   fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
+    #[allow(deprecated)] // will just become `pub(crate)` later
     match crate::number::complete::recognize_float_or_exceptions(i) {
       Err(e) => Err(e),
       Ok((i, s)) => {
@@ -1248,6 +1249,7 @@ mod streaming {
 
   #[cfg(feature = "std")]
   fn parse_f64(i: Streaming<&str>) -> IResult<Streaming<&str>, f64, ()> {
+    #[allow(deprecated)] // will just become `pub(crate)` later
     match crate::number::streaming::recognize_float_or_exceptions(i) {
       Err(e) => Err(e),
       Ok((i, s)) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -174,6 +174,8 @@ pub enum Err<E> {
   ///
   /// This must only be set when the `Input` is [`InputIsStreaming<true>`], like with
   /// [`Streaming`][crate::input::Streaming]
+  ///
+  /// Convert this into an `Error` with [`nom::combinator::complete`][crate::combinator::complete]
   Incomplete(Needed),
   /// The parser had an error (recoverable)
   Error(E),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,6 +117,9 @@ where
 }
 
 /// Contains information on needed data if a parser returned `Incomplete`
+///
+/// **Note:** This is only possible for `Input` types that implement [`InputIsStreaming<true>`],
+/// like [`Streaming`][crate::input::Streaming].
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub enum Needed {
@@ -154,7 +157,7 @@ impl Needed {
 ///
 /// It has three cases:
 ///
-/// * `Incomplete` indicates that more data is needed to decide. The `Needed` enum
+/// * `Incomplete` indicates that more data is needed to decide. The [`Needed`] enum
 /// can contain how many additional bytes are necessary. If you are sure your parser
 /// is working on full data, you can wrap your parser with the `complete` combinator
 /// to transform that case in `Error`
@@ -168,6 +171,9 @@ impl Needed {
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub enum Err<E> {
   /// There was not enough data
+  ///
+  /// This must only be set when the `Input` is [`InputIsStreaming<true>`], like with
+  /// [`Streaming`][crate::input::Streaming]
   Incomplete(Needed),
   /// The parser had an error (recoverable)
   Error(E),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -53,7 +53,7 @@ pub trait FinishIResult<I, O, E> {
 
 impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E>
 where
-  I: crate::input::InputLength + Clone,
+  I: crate::input::InputLength + crate::input::IntoOutput + Clone,
   E: crate::error::ParseError<I>,
 {
   fn finish(self) -> Result<O, E> {
@@ -96,6 +96,21 @@ impl<I, O, E> Finish<I, O, E> for IResult<I, O, E> {
         panic!("Cannot call `finish()` on `Err(Err::Incomplete(_))`: this result means that the parser does not have enough data to decide, you should gather more data and try to reapply  the parser instead")
       }
     }
+  }
+}
+
+/// Convert an `Input` into an appropriate `Output` type
+pub trait IntoOutputIResult<I, O, E> {
+  /// Convert an `Input` into an appropriate `Output` type
+  fn into_output(self) -> IResult<I, O, E>;
+}
+
+impl<I, E> IntoOutputIResult<I, <I as crate::input::IntoOutput>::Output, E> for IResult<I, I, E>
+where
+  I: crate::input::IntoOutput,
+{
+  fn into_output(self) -> IResult<I, <I as crate::input::IntoOutput>::Output, E> {
+    self.map(|(i, o)| (i, o.into_output()))
   }
 }
 

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -17,7 +17,7 @@ use crate::{IResult, Parser};
 /// # use nom::{Err, error::ErrorKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::pair;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// let mut parser = pair(tag("abc"), tag("efg"));
 ///
@@ -51,7 +51,7 @@ where
 /// # use nom::{Err, error::ErrorKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::preceded;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// let mut parser = preceded(tag("abc"), tag("efg"));
 ///
@@ -85,7 +85,7 @@ where
 /// # use nom::{Err, error::ErrorKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::terminated;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// let mut parser = terminated(tag("abc"), tag("efg"));
 ///
@@ -121,7 +121,7 @@ where
 /// # use nom::{Err, error::ErrorKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::separated_pair;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
 ///
@@ -160,7 +160,7 @@ where
 /// # use nom::{Err, error::ErrorKind, Needed};
 /// # use nom::Needed::Size;
 /// use nom::sequence::delimited;
-/// use nom::bytes::complete::tag;
+/// use nom::bytes::tag;
 ///
 /// let mut parser = delimited(tag("("), tag("abc"), tag(")"));
 ///
@@ -266,7 +266,7 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// ```rust
 /// # use nom::{Err, error::ErrorKind};
 /// use nom::sequence::tuple;
-/// use nom::character::complete::{alpha1, digit1};
+/// use nom::character::{alpha1, digit1};
 /// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -1,12 +1,13 @@
 use super::*;
-use crate::bytes::streaming::{tag, take};
+use crate::bytes::{tag, take};
 use crate::error::{Error, ErrorKind};
-use crate::number::streaming::be_u16;
+use crate::input::Streaming;
+use crate::number::be_u16;
 use crate::{Err, IResult, Needed};
 
 #[test]
 fn single_element_tuples() {
-  use crate::character::complete::alpha1;
+  use crate::character::alpha1;
   use crate::{error::ErrorKind, Err};
 
   let mut parser = tuple((alpha1,));
@@ -70,7 +71,7 @@ fn error_to_string<P: Clone + PartialEq>(e: &Context<P, u32>) -> &'static str {
 
 #[test]
 fn complete() {
-  use crate::bytes::complete::tag;
+  use crate::bytes::tag;
   fn err_test(i: &[u8]) -> IResult<&[u8], &[u8]> {
     let (i, _) = tag("ijkl")(i)?;
     tag("mnop")(i)
@@ -86,190 +87,244 @@ fn complete() {
 
 #[test]
 fn pair_test() {
-  fn pair_abc_def(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+  fn pair_abc_def(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
     pair(tag("abc"), tag("def"))(i)
   }
 
   assert_eq!(
-    pair_abc_def(&b"abcdefghijkl"[..]),
-    Ok((&b"ghijkl"[..], (&b"abc"[..], &b"def"[..])))
+    pair_abc_def(Streaming(&b"abcdefghijkl"[..])),
+    Ok((Streaming(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
   );
   assert_eq!(
-    pair_abc_def(&b"ab"[..]),
+    pair_abc_def(Streaming(&b"ab"[..])),
     Err(Err::Incomplete(Needed::new(1)))
   );
   assert_eq!(
-    pair_abc_def(&b"abcd"[..]),
+    pair_abc_def(Streaming(&b"abcd"[..])),
     Err(Err::Incomplete(Needed::new(2)))
   );
   assert_eq!(
-    pair_abc_def(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    pair_abc_def(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    pair_abc_def(&b"xxxdef"[..]),
-    Err(Err::Error(error_position!(&b"xxxdef"[..], ErrorKind::Tag)))
+    pair_abc_def(Streaming(&b"xxxdef"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxdef"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    pair_abc_def(&b"abcxxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    pair_abc_def(Streaming(&b"abcxxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn separated_pair_test() {
-  fn sep_pair_abc_def(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
+  fn sep_pair_abc_def(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
     separated_pair(tag("abc"), tag(","), tag("def"))(i)
   }
 
   assert_eq!(
-    sep_pair_abc_def(&b"abc,defghijkl"[..]),
-    Ok((&b"ghijkl"[..], (&b"abc"[..], &b"def"[..])))
+    sep_pair_abc_def(Streaming(&b"abc,defghijkl"[..])),
+    Ok((Streaming(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
   );
   assert_eq!(
-    sep_pair_abc_def(&b"ab"[..]),
+    sep_pair_abc_def(Streaming(&b"ab"[..])),
     Err(Err::Incomplete(Needed::new(1)))
   );
   assert_eq!(
-    sep_pair_abc_def(&b"abc,d"[..]),
+    sep_pair_abc_def(Streaming(&b"abc,d"[..])),
     Err(Err::Incomplete(Needed::new(2)))
   );
   assert_eq!(
-    sep_pair_abc_def(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    sep_pair_abc_def(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    sep_pair_abc_def(&b"xxx,def"[..]),
-    Err(Err::Error(error_position!(&b"xxx,def"[..], ErrorKind::Tag)))
+    sep_pair_abc_def(Streaming(&b"xxx,def"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx,def"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    sep_pair_abc_def(&b"abc,xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    sep_pair_abc_def(Streaming(&b"abc,xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn preceded_test() {
-  fn preceded_abcd_efgh(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn preceded_abcd_efgh(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     preceded(tag("abcd"), tag("efgh"))(i)
   }
 
   assert_eq!(
-    preceded_abcd_efgh(&b"abcdefghijkl"[..]),
-    Ok((&b"ijkl"[..], &b"efgh"[..]))
+    preceded_abcd_efgh(Streaming(&b"abcdefghijkl"[..])),
+    Ok((Streaming(&b"ijkl"[..]), &b"efgh"[..]))
   );
   assert_eq!(
-    preceded_abcd_efgh(&b"ab"[..]),
+    preceded_abcd_efgh(Streaming(&b"ab"[..])),
     Err(Err::Incomplete(Needed::new(2)))
   );
   assert_eq!(
-    preceded_abcd_efgh(&b"abcde"[..]),
+    preceded_abcd_efgh(Streaming(&b"abcde"[..])),
     Err(Err::Incomplete(Needed::new(3)))
   );
   assert_eq!(
-    preceded_abcd_efgh(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    preceded_abcd_efgh(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    preceded_abcd_efgh(&b"xxxxdef"[..]),
-    Err(Err::Error(error_position!(&b"xxxxdef"[..], ErrorKind::Tag)))
+    preceded_abcd_efgh(Streaming(&b"xxxxdef"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxxdef"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    preceded_abcd_efgh(&b"abcdxxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    preceded_abcd_efgh(Streaming(&b"abcdxxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn terminated_test() {
-  fn terminated_abcd_efgh(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn terminated_abcd_efgh(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     terminated(tag("abcd"), tag("efgh"))(i)
   }
 
   assert_eq!(
-    terminated_abcd_efgh(&b"abcdefghijkl"[..]),
-    Ok((&b"ijkl"[..], &b"abcd"[..]))
+    terminated_abcd_efgh(Streaming(&b"abcdefghijkl"[..])),
+    Ok((Streaming(&b"ijkl"[..]), &b"abcd"[..]))
   );
   assert_eq!(
-    terminated_abcd_efgh(&b"ab"[..]),
+    terminated_abcd_efgh(Streaming(&b"ab"[..])),
     Err(Err::Incomplete(Needed::new(2)))
   );
   assert_eq!(
-    terminated_abcd_efgh(&b"abcde"[..]),
+    terminated_abcd_efgh(Streaming(&b"abcde"[..])),
     Err(Err::Incomplete(Needed::new(3)))
   );
   assert_eq!(
-    terminated_abcd_efgh(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    terminated_abcd_efgh(Streaming(&b"xxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    terminated_abcd_efgh(&b"xxxxdef"[..]),
-    Err(Err::Error(error_position!(&b"xxxxdef"[..], ErrorKind::Tag)))
+    terminated_abcd_efgh(Streaming(&b"xxxxdef"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxxdef"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    terminated_abcd_efgh(&b"abcdxxxx"[..]),
-    Err(Err::Error(error_position!(&b"xxxx"[..], ErrorKind::Tag)))
+    terminated_abcd_efgh(Streaming(&b"abcdxxxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn delimited_test() {
-  fn delimited_abc_def_ghi(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn delimited_abc_def_ghi(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     delimited(tag("abc"), tag("def"), tag("ghi"))(i)
   }
 
   assert_eq!(
-    delimited_abc_def_ghi(&b"abcdefghijkl"[..]),
-    Ok((&b"jkl"[..], &b"def"[..]))
+    delimited_abc_def_ghi(Streaming(&b"abcdefghijkl"[..])),
+    Ok((Streaming(&b"jkl"[..]), &b"def"[..]))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"ab"[..]),
+    delimited_abc_def_ghi(Streaming(&b"ab"[..])),
     Err(Err::Incomplete(Needed::new(1)))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"abcde"[..]),
+    delimited_abc_def_ghi(Streaming(&b"abcde"[..])),
     Err(Err::Incomplete(Needed::new(1)))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"abcdefgh"[..]),
+    delimited_abc_def_ghi(Streaming(&b"abcdefgh"[..])),
     Err(Err::Incomplete(Needed::new(1)))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"xxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
-  );
-  assert_eq!(
-    delimited_abc_def_ghi(&b"xxxdefghi"[..]),
+    delimited_abc_def_ghi(Streaming(&b"xxx"[..])),
     Err(Err::Error(error_position!(
-      &b"xxxdefghi"[..],
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
+  );
+  assert_eq!(
+    delimited_abc_def_ghi(Streaming(&b"xxxdefghi"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxdefghi"[..]),
       ErrorKind::Tag
     ),))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"abcxxxghi"[..]),
-    Err(Err::Error(error_position!(&b"xxxghi"[..], ErrorKind::Tag)))
+    delimited_abc_def_ghi(Streaming(&b"abcxxxghi"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxxghi"[..]),
+      ErrorKind::Tag
+    )))
   );
   assert_eq!(
-    delimited_abc_def_ghi(&b"abcdefxxx"[..]),
-    Err(Err::Error(error_position!(&b"xxx"[..], ErrorKind::Tag)))
+    delimited_abc_def_ghi(Streaming(&b"abcdefxxx"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"xxx"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 
 #[test]
 fn tuple_test() {
-  fn tuple_3(i: &[u8]) -> IResult<&[u8], (u16, &[u8], &[u8])> {
+  fn tuple_3(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (u16, &[u8], &[u8])> {
     tuple((be_u16, take(3u8), tag("fg")))(i)
   }
 
   assert_eq!(
-    tuple_3(&b"abcdefgh"[..]),
-    Ok((&b"h"[..], (0x6162u16, &b"cde"[..], &b"fg"[..])))
+    tuple_3(Streaming(&b"abcdefgh"[..])),
+    Ok((Streaming(&b"h"[..]), (0x6162u16, &b"cde"[..], &b"fg"[..])))
   );
-  assert_eq!(tuple_3(&b"abcd"[..]), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(tuple_3(&b"abcde"[..]), Err(Err::Incomplete(Needed::new(2))));
   assert_eq!(
-    tuple_3(&b"abcdejk"[..]),
-    Err(Err::Error(error_position!(&b"jk"[..], ErrorKind::Tag)))
+    tuple_3(Streaming(&b"abcd"[..])),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    tuple_3(Streaming(&b"abcde"[..])),
+    Err(Err::Incomplete(Needed::new(2)))
+  );
+  assert_eq!(
+    tuple_3(Streaming(&b"abcdejk"[..])),
+    Err(Err::Error(error_position!(
+      Streaming(&b"jk"[..]),
+      ErrorKind::Tag
+    )))
   );
 }
 

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -1,8 +1,8 @@
 use nom::{
   branch::alt,
-  bytes::complete::tag,
-  character::complete::char,
-  character::complete::{digit1 as digit, space0 as space},
+  bytes::tag,
+  character::char,
+  character::{digit1 as digit, space0 as space},
   combinator::map_res,
   multi::fold_many0,
   sequence::{delimited, pair},

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 
 use nom::{
   branch::alt,
-  bytes::complete::tag,
-  character::complete::{digit1 as digit, multispace0 as multispace},
+  bytes::tag,
+  character::{digit1 as digit, multispace0 as multispace},
   combinator::{map, map_res},
   multi::many0,
   sequence::{delimited, preceded},

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -1,4 +1,4 @@
-use nom::bytes::complete::{tag, take_while_m_n};
+use nom::bytes::{tag, take_while_m_n};
 use nom::combinator::map_res;
 use nom::sequence::tuple;
 use nom::IResult;

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)]
 
-use nom::bytes::streaming::tag;
-use nom::character::streaming::digit1 as digit;
+use nom::bytes::tag;
+use nom::character::digit1 as digit;
 use nom::combinator::verify;
 use nom::error::{ErrorKind, ParseError};
+use nom::input::Streaming;
 #[cfg(feature = "alloc")]
 use nom::multi::count;
 use nom::sequence::terminated;
@@ -18,31 +19,31 @@ impl<'a> From<(&'a str, ErrorKind)> for CustomError {
   }
 }
 
-impl<'a> ParseError<&'a str> for CustomError {
-  fn from_error_kind(_: &'a str, kind: ErrorKind) -> Self {
+impl<'a> ParseError<Streaming<&'a str>> for CustomError {
+  fn from_error_kind(_: Streaming<&'a str>, kind: ErrorKind) -> Self {
     CustomError(format!("error code was: {:?}", kind))
   }
 
-  fn append(_: &'a str, kind: ErrorKind, other: CustomError) -> Self {
+  fn append(_: Streaming<&'a str>, kind: ErrorKind, other: CustomError) -> Self {
     CustomError(format!("{:?}\nerror code was: {:?}", other, kind))
   }
 }
 
-fn test1(input: &str) -> IResult<&str, &str, CustomError> {
+fn test1(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> {
   //fix_error!(input, CustomError, tag!("abcd"))
   tag("abcd")(input)
 }
 
-fn test2(input: &str) -> IResult<&str, &str, CustomError> {
+fn test2(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> {
   //terminated!(input, test1, fix_error!(CustomError, digit))
   terminated(test1, digit)(input)
 }
 
-fn test3(input: &str) -> IResult<&str, &str, CustomError> {
+fn test3(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> {
   verify(test1, |s: &str| s.starts_with("abcd"))(input)
 }
 
 #[cfg(feature = "alloc")]
-fn test4(input: &str) -> IResult<&str, Vec<&str>, CustomError> {
+fn test4(input: Streaming<&str>) -> IResult<Streaming<&str>, Vec<&str>, CustomError> {
   count(test1, 4)(input)
 }

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -1,6 +1,6 @@
-use nom::bytes::complete::escaped;
-use nom::character::complete::digit1;
-use nom::character::complete::one_of;
+use nom::bytes::escaped;
+use nom::character::digit1;
+use nom::character::one_of;
 use nom::{error::ErrorKind, Err, IResult};
 
 fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
@@ -9,7 +9,7 @@ fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
 
 #[cfg(feature = "alloc")]
 fn esc_trans(s: &str) -> IResult<&str, String, (&str, ErrorKind)> {
-  use nom::bytes::complete::{escaped_transform, tag};
+  use nom::bytes::{escaped_transform, tag};
   escaped_transform(digit1, '\\', tag("n"))(s)
 }
 

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,6 +1,6 @@
 use nom::branch::alt;
-use nom::bytes::complete::tag;
-use nom::character::streaming::digit1 as digit;
+use nom::bytes::tag;
+use nom::character::digit1 as digit;
 use nom::combinator::{map, map_res, opt, recognize};
 use nom::sequence::{delimited, pair};
 use nom::IResult;

--- a/tests/fnmut.rs
+++ b/tests/fnmut.rs
@@ -1,5 +1,5 @@
 use nom::{
-  bytes::complete::tag,
+  bytes::tag,
   multi::{many0, many0_count},
 };
 

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -1,8 +1,6 @@
 use nom::{
-  bytes::complete::take_while,
-  character::complete::{
-    alphanumeric1 as alphanumeric, char, multispace0 as multispace, space0 as space,
-  },
+  bytes::take_while,
+  character::{alphanumeric1 as alphanumeric, char, multispace0 as multispace, space0 as space},
   combinator::{map, map_res, opt},
   multi::many0,
   sequence::{delimited, pair, separated_pair, terminated, tuple},

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,6 +1,6 @@
 use nom::{
-  bytes::complete::{is_a, tag, take_till, take_while},
-  character::complete::{alphanumeric1 as alphanumeric, char, space0 as space},
+  bytes::{is_a, tag, take_till, take_while},
+  character::{alphanumeric1 as alphanumeric, char, space0 as space},
   combinator::opt,
   multi::many0,
   sequence::{delimited, pair, terminated, tuple},

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
 
+use nom::input::Streaming;
 use nom::{error::ErrorKind, Err, IResult, Needed};
 
 #[allow(dead_code)]
@@ -21,19 +22,20 @@ pub fn take_char(input: &[u8]) -> IResult<&[u8], char> {
 #[cfg(feature = "std")]
 mod parse_int {
   use nom::input::HexDisplay;
+  use nom::input::Streaming;
   use nom::{
-    character::streaming::{digit1 as digit, space1 as space},
+    character::{digit1 as digit, space1 as space},
     combinator::{complete, map, opt},
     multi::many0,
     IResult,
   };
   use std::str;
 
-  fn parse_ints(input: &[u8]) -> IResult<&[u8], Vec<i32>> {
+  fn parse_ints(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<i32>> {
     many0(spaces_or_int)(input)
   }
 
-  fn spaces_or_int(input: &[u8]) -> IResult<&[u8], i32> {
+  fn spaces_or_int(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i32> {
     println!("{}", input.to_hex(8));
     let (i, _) = opt(complete(space))(input)?;
     let (i, res) = map(complete(digit), |x| {
@@ -52,12 +54,12 @@ mod parse_int {
 
   #[test]
   fn issue_142() {
-    let subject = parse_ints(&b"12 34 5689a"[..]);
-    let expected = Ok((&b"a"[..], vec![12, 34, 5689]));
+    let subject = parse_ints(Streaming(&b"12 34 5689a"[..]));
+    let expected = Ok((Streaming(&b"a"[..]), vec![12, 34, 5689]));
     assert_eq!(subject, expected);
 
-    let subject = parse_ints(&b"12 34 5689 "[..]);
-    let expected = Ok((&b" "[..], vec![12, 34, 5689]));
+    let subject = parse_ints(Streaming(&b"12 34 5689 "[..]));
+    let expected = Ok((Streaming(&b" "[..]), vec![12, 34, 5689]));
     assert_eq!(subject, expected)
   }
 }
@@ -65,26 +67,33 @@ mod parse_int {
 #[test]
 fn usize_length_bytes_issue() {
   use nom::multi::length_data;
-  use nom::number::streaming::be_u16;
-  let _: IResult<&[u8], &[u8], (&[u8], ErrorKind)> = length_data(be_u16)(b"012346");
+  use nom::number::be_u16;
+  let _: IResult<Streaming<&[u8]>, &[u8], (Streaming<&[u8]>, ErrorKind)> =
+    length_data(be_u16)(Streaming(b"012346"));
 }
 
 #[test]
 fn take_till_issue() {
-  use nom::bytes::streaming::take_till;
+  use nom::bytes::take_till;
 
-  fn nothing(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn nothing(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     take_till(|_| true)(i)
   }
 
-  assert_eq!(nothing(b""), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(nothing(b"abc"), Ok((&b"abc"[..], &b""[..])));
+  assert_eq!(
+    nothing(Streaming(b"")),
+    Err(Err::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    nothing(Streaming(b"abc")),
+    Ok((Streaming(&b"abc"[..]), &b""[..]))
+  );
 }
 
 #[test]
 fn issue_655() {
-  use nom::character::streaming::{line_ending, not_line_ending};
-  fn twolines(i: &str) -> IResult<&str, (&str, &str)> {
+  use nom::character::{line_ending, not_line_ending};
+  fn twolines(i: Streaming<&str>) -> IResult<Streaming<&str>, (&str, &str)> {
     let (i, l1) = not_line_ending(i)?;
     let (i, _) = line_ending(i)?;
     let (i, l2) = not_line_ending(i)?;
@@ -93,26 +102,38 @@ fn issue_655() {
     Ok((i, (l1, l2)))
   }
 
-  assert_eq!(twolines("foo\nbar\n"), Ok(("", ("foo", "bar"))));
-  assert_eq!(twolines("féo\nbar\n"), Ok(("", ("féo", "bar"))));
-  assert_eq!(twolines("foé\nbar\n"), Ok(("", ("foé", "bar"))));
-  assert_eq!(twolines("foé\r\nbar\n"), Ok(("", ("foé", "bar"))));
+  assert_eq!(
+    twolines(Streaming("foo\nbar\n")),
+    Ok((Streaming(""), ("foo", "bar")))
+  );
+  assert_eq!(
+    twolines(Streaming("féo\nbar\n")),
+    Ok((Streaming(""), ("féo", "bar")))
+  );
+  assert_eq!(
+    twolines(Streaming("foé\nbar\n")),
+    Ok((Streaming(""), ("foé", "bar")))
+  );
+  assert_eq!(
+    twolines(Streaming("foé\r\nbar\n")),
+    Ok((Streaming(""), ("foé", "bar")))
+  );
 }
 
 #[cfg(feature = "alloc")]
 fn issue_717(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-  use nom::bytes::complete::{is_not, tag};
+  use nom::bytes::{is_not, tag};
   use nom::multi::separated_list0;
 
   separated_list0(tag([0x0]), is_not([0x0u8]))(i)
 }
 
 mod issue_647 {
-  use nom::bytes::streaming::tag;
+  use nom::bytes::tag;
   use nom::combinator::complete;
   use nom::multi::separated_list0;
-  use nom::{error::Error, number::streaming::be_f64, Err, IResult};
-  pub type Input<'a> = &'a [u8];
+  use nom::{error::Error, number::be_f64, Err, IResult};
+  pub type Input<'a> = nom::input::Streaming<&'a [u8]>;
 
   #[derive(PartialEq, Debug, Clone)]
   struct Data {
@@ -123,7 +144,7 @@ mod issue_647 {
   fn list<'a, 'b>(
     input: Input<'a>,
     _cs: &'b f64,
-  ) -> Result<(Input<'a>, Vec<f64>), Err<Error<&'a [u8]>>> {
+  ) -> Result<(Input<'a>, Vec<f64>), Err<Error<Input<'a>>>> {
     separated_list0(complete(tag(",")), complete(be_f64))(input)
   }
 
@@ -137,19 +158,19 @@ mod issue_647 {
 
 #[test]
 fn issue_848_overflow_incomplete_bits_to_bytes() {
-  fn take(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    use nom::bytes::streaming::take;
+  fn take(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
+    use nom::bytes::take;
     take(0x2000000000000000_usize)(i)
   }
-  fn parser(i: &[u8]) -> IResult<&[u8], &[u8]> {
+  fn parser(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     use nom::bits::{bits, bytes};
 
     bits(bytes(take))(i)
   }
   assert_eq!(
-    parser(&b""[..]),
+    parser(Streaming(&b""[..])),
     Err(Err::Failure(nom::error_position!(
-      &b""[..],
+      Streaming(&b""[..]),
       ErrorKind::TooLarge
     )))
   );
@@ -161,7 +182,7 @@ fn issue_942() {
   pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
   ) -> IResult<&'a str, usize, E> {
-    use nom::{character::complete::char, error::context, multi::many0_count};
+    use nom::{character::char, error::context, multi::many0_count};
     many0_count(context("char_a", char('a')))(i)
   }
   assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
@@ -169,7 +190,7 @@ fn issue_942() {
 
 #[test]
 fn issue_many_m_n_with_zeros() {
-  use nom::character::complete::char;
+  use nom::character::char;
   use nom::multi::many_m_n;
   let mut parser = many_m_n::<_, _, (), _>(0, 0, char('a'));
   assert_eq!(parser("aaa"), Ok(("aaa", vec![])));
@@ -177,7 +198,7 @@ fn issue_many_m_n_with_zeros() {
 
 #[test]
 fn issue_1027_convert_error_panic_nonempty() {
-  use nom::character::complete::char;
+  use nom::character::char;
   use nom::error::{convert_error, VerboseError};
   use nom::sequence::pair;
 
@@ -209,15 +230,15 @@ fn issue_1231_bits_expect_fn_closure() {
 
 #[test]
 fn issue_1282_findtoken_char() {
-  use nom::character::complete::one_of;
+  use nom::character::one_of;
   use nom::error::Error;
-  let parser = one_of::<_, _, Error<_>>(&['a', 'b', 'c'][..]);
+  let parser = one_of::<_, _, Error<_>, false>(&['a', 'b', 'c'][..]);
   assert_eq!(parser("aaa"), Ok(("aa", 'a')));
 }
 
 #[test]
 fn issue_1459_clamp_capacity() {
-  use nom::character::complete::char;
+  use nom::character::char;
 
   // shouldn't panic
   use nom::multi::many_m_n;

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -198,7 +198,7 @@ fn issue_1027_convert_error_panic_nonempty() {
 
 #[test]
 fn issue_1231_bits_expect_fn_closure() {
-  use nom::bits::{bits, complete::take};
+  use nom::bits::{bits, take};
   use nom::error::Error;
   use nom::sequence::tuple;
   pub fn example(input: &[u8]) -> IResult<&[u8], (u8, u8)> {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -2,12 +2,12 @@
 
 use nom::{
   branch::alt,
-  bytes::complete::{tag, take},
-  character::complete::{anychar, char, multispace0, none_of},
+  bytes::{tag, take},
+  character::{anychar, char, multispace0, none_of},
   combinator::{map, map_opt, map_res, value, verify},
   error::ParseError,
   multi::{fold_many0, separated_list0},
-  number::complete::double,
+  number::double,
   sequence::{delimited, preceded, separated_pair},
   IResult, Parser,
 };

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -1,23 +1,24 @@
 #![allow(dead_code)]
 
+use nom::input::Streaming;
 use nom::{
   branch::alt,
-  bytes::streaming::{tag, take},
+  bytes::{tag, take},
   combinator::{map, map_res},
   error::ErrorKind,
   multi::many0,
-  number::streaming::{be_f32, be_u16, be_u32, be_u64},
+  number::{be_f32, be_u16, be_u32, be_u64},
   Err, IResult, Needed,
 };
 
 use std::str;
 
-fn mp4_box(input: &[u8]) -> IResult<&[u8], &[u8]> {
+fn mp4_box(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
   match be_u32(input) {
     Ok((i, offset)) => {
       let sz: usize = offset as usize;
       if i.len() >= sz - 4 {
-        Ok((&i[(sz - 4)..], &i[0..(sz - 4)]))
+        Ok((Streaming(&i[(sz - 4)..]), &i[0..(sz - 4)]))
       } else {
         Err(Err::Incomplete(Needed::new(offset as usize + 4)))
       }
@@ -95,7 +96,7 @@ pub struct Mvhd64 {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn mvhd32(i: &[u8]) -> IResult<&[u8], MvhdBox> {
+fn mvhd32(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MvhdBox> {
   let (i, version_flags) = be_u32(i)?;
   let (i, created_date) =  be_u32(i)?;
   let (i, modified_date) = be_u32(i)?;
@@ -147,7 +148,7 @@ fn mvhd32(i: &[u8]) -> IResult<&[u8], MvhdBox> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn mvhd64(i: &[u8]) -> IResult<&[u8], MvhdBox> {
+fn mvhd64(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MvhdBox> {
   let (i, version_flags) = be_u32(i)?;
   let (i, created_date) =  be_u64(i)?;
   let (i, modified_date) = be_u64(i)?;
@@ -243,11 +244,11 @@ struct MP4BoxHeader {
   tag: MP4BoxType,
 }
 
-fn brand_name(input: &[u8]) -> IResult<&[u8], &str> {
+fn brand_name(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &str> {
   map_res(take(4_usize), str::from_utf8)(input)
 }
 
-fn filetype_parser(input: &[u8]) -> IResult<&[u8], FileType<'_>> {
+fn filetype_parser(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, FileType<'_>> {
   let (i, name) = brand_name(input)?;
   let (i, version) = take(4_usize)(i)?;
   let (i, brands) = many0(brand_name)(i)?;
@@ -260,7 +261,7 @@ fn filetype_parser(input: &[u8]) -> IResult<&[u8], FileType<'_>> {
   Ok((i, ft))
 }
 
-fn mvhd_box(input: &[u8]) -> IResult<&[u8], MvhdBox> {
+fn mvhd_box(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MvhdBox> {
   let res = if input.len() < 100 {
     Err(Err::Incomplete(Needed::new(100)))
   } else if input.len() == 100 {
@@ -274,11 +275,11 @@ fn mvhd_box(input: &[u8]) -> IResult<&[u8], MvhdBox> {
   res
 }
 
-fn unknown_box_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
+fn unknown_box_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
   Ok((input, MP4BoxType::Unknown))
 }
 
-fn box_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
+fn box_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
   alt((
     map(tag("ftyp"), |_| MP4BoxType::Ftyp),
     map(tag("moov"), |_| MP4BoxType::Moov),
@@ -293,7 +294,7 @@ fn box_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
 // warning, an alt combinator with 9 branches containing a tag combinator
 // can make the compilation very slow. Use functions as sub parsers,
 // or split into multiple alt parsers if it gets slow
-fn moov_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
+fn moov_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
   alt((
     map(tag("mdra"), |_| MP4BoxType::Mdra),
     map(tag("dref"), |_| MP4BoxType::Dref),
@@ -307,13 +308,13 @@ fn moov_type(input: &[u8]) -> IResult<&[u8], MP4BoxType> {
   ))(input)
 }
 
-fn box_header(input: &[u8]) -> IResult<&[u8], MP4BoxHeader> {
+fn box_header(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxHeader> {
   let (i, length) = be_u32(input)?;
   let (i, tag) = box_type(i)?;
   Ok((i, MP4BoxHeader { length, tag }))
 }
 
-fn moov_header(input: &[u8]) -> IResult<&[u8], MP4BoxHeader> {
+fn moov_header(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxHeader> {
   let (i, length) = be_u32(input)?;
   let (i, tag) = moov_type(i)?;
   Ok((i, MP4BoxHeader { length, tag }))

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -1,5 +1,5 @@
 use nom::{
-  character::complete::{alphanumeric1 as alphanumeric, line_ending as eol},
+  character::{alphanumeric1 as alphanumeric, line_ending as eol},
   multi::many0,
   sequence::terminated,
   IResult,

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -3,8 +3,8 @@
 
 use std::str;
 
-use nom::bytes::complete::is_not;
-use nom::character::complete::char;
+use nom::bytes::is_not;
+use nom::character::char;
 use nom::combinator::{map, map_res};
 use nom::multi::fold_many0;
 use nom::sequence::delimited;


### PR DESCRIPTION
Previously in #6, I was transitioning parsers from returning `FnMut(I) -> IResult<I, O, E>` to structs that implement `Parser` so we could implement two unique parse traits, one for complete and one for streaming parsing.  That ran into a series of problems, including not-as-great type inference.

This PR takes a different approach by making the type of parser a property of the `Input`, using const-generics.  We can then specialize the implementation based on a `const STREAMING: bool`.

Potential downsides
- Intentionally mixing complete and streaming parsers due to complications with the error type
- Extra line noise for streaming users
  - I'm feeling like this will be acceptable as most of the noise is felt in tests and streaming is likely a less common case
- Output types not carrying `Streaming<T>` type
  - For `nom::bytes`, I automatically convert to the `Complete` type but that might not always be the most accurate. 
  - Unspecialzied functions, like `recognize`, can't be specialized without adding a new trait bound
  - We might want a dedicated trait for this as it feels incorrect to use `InputIsStreaming::Complete` for something unrelated to `Complete` vs `Streaming` and to use that trait in non-specialized places

Steps
- [x] Create context-sensitive streaming/complete parsers
- [x] Migrate all code off of streaming/complete-specific parsers
- [x] Deprecate streaming/complete-specific parsers
- [x] Ensure `Streaming` documentation is sufficient
- [x] Resolve anything else returning Incomplete (e.g. `length_data`)
- [ ] ~~Constrain `nom::combinator::complete` to streaming (move to trait, deprecating old version?)~~
  - As shown by `length_value`, `complete` can be useful in `InputIsStreaming` agnostic code.

Fixes Geal/nom#1535