### PR TITLE
feat: Add FinishIResult::finish to drop remaining input 

### DIFF
--- a/benchmarks/benches/http.rs
+++ b/benchmarks/benches/http.rs
@@ -173,7 +173,7 @@ Connection: keep-alive
     b.iter(|| parse(data).unwrap());
   });
 
-  http_group.finish_err();
+  http_group.finish();
 }
 
 /*

--- a/benchmarks/benches/http.rs
+++ b/benchmarks/benches/http.rs
@@ -173,7 +173,7 @@ Connection: keep-alive
     b.iter(|| parse(data).unwrap());
   });
 
-  http_group.finish();
+  http_group.finish_err();
 }
 
 /*

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -374,7 +374,7 @@
 //!   type Err = Error<String>;
 //!
 //!   fn from_str(s: &str) -> Result<Self, Self::Err> {
-//!       match parse_name(s).finish() {
+//!       match parse_name(s).finish_err() {
 //!           Ok((_remaining, name)) => Ok(Name(name.to_string())),
 //!           Err(Error { input, code }) => Err(Error {
 //!               input: input.to_string(),

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -374,8 +374,8 @@
 //!   type Err = Error<String>;
 //!
 //!   fn from_str(s: &str) -> Result<Self, Self::Err> {
-//!       match parse_name(s).finish_err() {
-//!           Ok((_remaining, name)) => Ok(Name(name.to_string())),
+//!       match parse_name(s).finish() {
+//!           Ok(name) => Ok(Name(name.to_string())),
 //!           Err(Error { input, code }) => Err(Error {
 //!               input: input.to_string(),
 //!               code,

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@
 //!
 //! If we are running a parser and know it will not return `Err::Incomplete`, we can
 //! directly extract the error type from `Err::Error` or `Err::Failure` with the
-//! `finish_err()` method:
+//! `finish()` method:
 //!
 //! ```rust,ignore
 //! # use nom::IResult;
@@ -43,7 +43,7 @@
 //! # let parser = nom::bytes::complete::take_while1(|c: char| c == ' ');
 //! # let input = " ";
 //! let parser_result: IResult<_, _, _> = parser(input);
-//! let result: Result<(_, _), _> = parser_result.finish_err();
+//! let result: Result<_, _> = parser_result.finish();
 //! ```
 //!
 //! If we used a borrowed type as input, like `&[u8]` or `&str`, we might want to
@@ -225,7 +225,7 @@
 //! can build such a message.
 //!
 //! ```rust,ignore
-//! let e = json::<VerboseError<&str>>(data).finish_err().err().unwrap();
+//! let e = json::<VerboseError<&str>>(data).finish().err().unwrap();
 //! // here we use the `convert_error` function, to transform a `VerboseError<&str>`
 //! // into a printable trace.
 //! //

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@
 //!
 //! If we are running a parser and know it will not return `Err::Incomplete`, we can
 //! directly extract the error type from `Err::Error` or `Err::Failure` with the
-//! `finish()` method:
+//! `finish_err()` method:
 //!
 //! ```rust,ignore
 //! # use nom::IResult;
@@ -43,7 +43,7 @@
 //! # let parser = nom::bytes::complete::take_while1(|c: char| c == ' ');
 //! # let input = " ";
 //! let parser_result: IResult<_, _, _> = parser(input);
-//! let result: Result<(_, _), _> = parser_result.finish();
+//! let result: Result<(_, _), _> = parser_result.finish_err();
 //! ```
 //!
 //! If we used a borrowed type as input, like `&[u8]` or `&str`, we might want to
@@ -225,7 +225,7 @@
 //! can build such a message.
 //!
 //! ```rust,ignore
-//! let e = json::<VerboseError<&str>>(data).finish().err().unwrap();
+//! let e = json::<VerboseError<&str>>(data).finish_err().err().unwrap();
 //! // here we use the `convert_error` function, to transform a `VerboseError<&str>`
 //! // into a printable trace.
 //! //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,12 @@
 //! }
 //!
 //! fn main() {
-//!   let result = hex_color("#2F14DF").finish_err();
-//!   assert_eq!(result, Ok(("", Color {
+//!   let result = hex_color("#2F14DF").finish();
+//!   assert_eq!(result, Ok(Color {
 //!     red: 47,
 //!     green: 20,
 //!     blue: 223,
-//!   })));
+//!   }));
 //! }
 //! ```
 //!
@@ -481,8 +481,8 @@ pub mod _tutorial;
 /// }
 ///
 /// fn main() {
-///   let result = parse_data.parse("100").finish_err();
-///   assert_eq!(result, Ok(("", 100)));
+///   let result = parse_data.parse("100").finish();
+///   assert_eq!(result, Ok(100));
 /// }
 /// ```
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! }
 //!
 //! fn main() {
-//!   let result = hex_color("#2F14DF").finish();
+//!   let result = hex_color("#2F14DF").finish_err();
 //!   assert_eq!(result, Ok(("", Color {
 //!     red: 47,
 //!     green: 20,
@@ -481,7 +481,7 @@ pub mod _tutorial;
 /// }
 ///
 /// fn main() {
-///   let result = parse_data.parse("100").finish();
+///   let result = parse_data.parse("100").finish_err();
 ///   assert_eq!(result, Ok(("", 100)));
 /// }
 /// ```

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use core::num::NonZeroUsize;
 /// The `Ok` side is a pair containing the remainder of the input (the part of the data that
 /// was not parsed) and the produced value. The `Err` side contains an instance of `nom::Err`.
 ///
-/// Outside of the parsing code, you can use the [`FinishIResult::finish`] method to convert
+/// Outside of the parsing code, you can use the [`FinishIResult::finish_err`] method to convert
 /// it to a more common result type
 pub type IResult<I, O, E = error::Error<I>> = Result<(I, O), Err<E>>;
 
@@ -32,17 +32,17 @@ pub trait FinishIResult<I, O, E> {
   /// - "streaming" parsers: `Incomplete` will be returned if there's not enough data
   /// for the parser to decide, and you should gather more data before parsing again.
   /// Once the parser returns either `Ok(_)`, `Err(Err::Error(_))` or `Err(Err::Failure(_))`,
-  /// you can get out of the parsing loop and call `finish()` on the parser's result
-  fn finish(self) -> Result<(I, O), E>;
+  /// you can get out of the parsing loop and call `finish_err()` on the parser's result
+  fn finish_err(self) -> Result<(I, O), E>;
 }
 
 impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E> {
-  fn finish(self) -> Result<(I, O), E> {
+  fn finish_err(self) -> Result<(I, O), E> {
     match self {
       Ok(res) => Ok(res),
       Err(Err::Error(e)) | Err(Err::Failure(e)) => Err(e),
       Err(Err::Incomplete(_)) => {
-        panic!("Cannot call `finish()` on `Err(Err::Incomplete(_))`: this result means that the parser does not have enough data to decide, you should gather more data and try to reapply  the parser instead")
+        panic!("Cannot call `finish_err()` on `Err(Err::Incomplete(_))`: this result means that the parser does not have enough data to decide, you should gather more data and try to reapply  the parser instead")
       }
     }
   }
@@ -54,6 +54,10 @@ impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E> {
   note = "Replaced with `FinishIResult` which is available via `nom::prelude`"
 )]
 pub trait Finish<I, O, E> {
+  #[deprecated(
+    since = "8.0.0",
+    note = "Replaced with `FinishIResult::finish_err` which is available via `nom::prelude`"
+  )]
   fn finish(self) -> Result<(I, O), E>;
 }
 


### PR DESCRIPTION
It seems like the need for this is common enough to be worth having,
especially to drive correct behavior as this change highlights several
examples that ignored remaining input even when that isn't correct
(like in a `FromStr`).

This does add extra bounds for `FinishIResult`.  I had considered making
a separate extension trait but the likelihood it would be needed is low.
If anything, I could see adding an `InputIsEmpty` trait and moving it to
that as that would be more universal (could work on some iterators).  If
we really need it, we can split the traits (create a
`FinishErrIResult`).  Let's see what feedback we get.

To make room for this, we renamed the existing `finish` to `finish_err`.