### PR TITLE
refactor(multi): Reuse some length_data logic

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -226,6 +226,24 @@ where
   }
 }
 
+/// Implementation of [`Parser::as_mut_parser`][Parser::as_mut_parser]
+#[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
+pub struct MutParser<'p, P> {
+  p: &'p mut P,
+}
+
+impl<'p, P> MutParser<'p, P> {
+  pub(crate) fn new(p: &'p mut P) -> Self {
+    Self { p }
+  }
+}
+
+impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for MutParser<'p, P> {
+  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+    self.p.parse(i)
+  }
+}
+
 /// Implementation of `Parser::map`
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub struct Map<F, G, O1> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -44,6 +44,8 @@
 //! |---|---|
 //! | [AsChar][AsChar] |Transforms common types to a char for basic token parsing|
 
+use core::num::NonZeroUsize;
+
 use crate::error::{ErrorKind, ParseError};
 use crate::lib::std::iter::{Copied, Enumerate};
 use crate::lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
@@ -422,10 +424,10 @@ impl<'a> InputIter for &'a [u8] {
   }
   #[inline]
   fn slice_index(&self, count: usize) -> Result<usize, Needed> {
-    if self.len() >= count {
-      Ok(count)
+    if let Some(needed) = count.checked_sub(self.len()).and_then(NonZeroUsize::new) {
+      Err(Needed::Size(needed))
     } else {
-      Err(Needed::new(count - self.len()))
+      Ok(count)
     }
   }
 }


### PR DESCRIPTION
We had to copy/paste parser definitions like `length_data` into `length_value` because it requires passing moving a parser from the caller to the `length_data` but we return a `FnMut` instead of a `FnOnce`, allowing `length_value` to be called multiple times.

What we need is to implement `Parser` for `&mut impl Parser` but we can't until negative impl traits are a thing.  So instead, this adds a new combinator to wrap `&mut impl Parser` in a type that implements `Parser`.  The name isn't great but we can change it later once we get a better one.