### PR TITLE
fix: Aim for one way of doing a parser

### DIFF
--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "alloc")]
 
+use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::{escaped, tag, take_while},
   character::{alphanumeric1 as alphanumeric, char, one_of},
-  combinator::{cut, map},
+  combinator::cut,
   error::{context, ParseError},
   multi::separated_list0,
   number::double,
@@ -233,7 +234,7 @@ fn string<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
 }
 
 fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
-  alt((map(tag("false"), |_| false), map(tag("true"), |_| true)))(input)
+  alt((tag("false").map(|_| false), tag("true").map(|_| true)))(input)
 }
 
 fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
@@ -242,7 +243,7 @@ fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
     preceded(
       char('['),
       cut(terminated(
-        map(separated_list0(preceded(sp, char(',')), value), |_| ()),
+        separated_list0(preceded(sp, char(',')), value).map(|_| ()),
         preceded(sp, char(']')),
       )),
     ),
@@ -259,7 +260,7 @@ fn hash<'a>(i: &'a str) -> IResult<&'a str, ()> {
     preceded(
       char('{'),
       cut(terminated(
-        map(separated_list0(preceded(sp, char(',')), key_value), |_| ()),
+        separated_list0(preceded(sp, char(',')), key_value).map(|_| ()),
         preceded(sp, char('}')),
       )),
     ),
@@ -272,9 +273,9 @@ fn value<'a>(i: &'a str) -> IResult<&'a str, ()> {
     alt((
       hash,
       array,
-      map(string, |_| ()),
-      map(double, |_| ()),
-      map(boolean, |_| ()),
+      string.map(|_| ()),
+      double.map(|_| ()),
+      boolean.map(|_| ()),
     )),
   )(i)
 }

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -14,9 +14,10 @@
 use nom::branch::alt;
 use nom::bytes::{is_not, take_while_m_n};
 use nom::character::{char, multispace1};
-use nom::combinator::{map, map_opt, map_res, value, verify};
+use nom::combinator::{map_opt, map_res, value, verify};
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
+use nom::prelude::*;
 use nom::sequence::{delimited, preceded};
 use nom::IResult;
 
@@ -124,8 +125,8 @@ where
   alt((
     // The `map` combinator runs a parser, then applies a function to the output
     // of that parser.
-    map(parse_literal, StringFragment::Literal),
-    map(parse_escaped_char, StringFragment::EscapedChar),
+    parse_literal.map(StringFragment::Literal),
+    parse_escaped_char.map(StringFragment::EscapedChar),
     value(StringFragment::EscapedWS, parse_escaped_whitespace),
   ))(input)
 }

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -10,12 +10,7 @@ use crate::Err;
 use crate::IResult;
 use crate::Needed;
 #[cfg(feature = "alloc")]
-use crate::{
-  branch::alt,
-  combinator::{map, value},
-  lib::std::string::String,
-  lib::std::vec::Vec,
-};
+use crate::{branch::alt, combinator::value, lib::std::string::String, lib::std::vec::Vec};
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
@@ -146,18 +141,17 @@ fn complete_escape_transform() {
   use crate::character::alpha1 as alpha;
 
   fn esc(i: &[u8]) -> IResult<&[u8], String> {
-    map(
-      escaped_transform(
-        alpha,
-        '\\',
-        alt((
-          value(&b"\\"[..], tag("\\")),
-          value(&b"\""[..], tag("\"")),
-          value(&b"\n"[..], tag("n")),
-        )),
-      ),
-      to_s,
-    )(i)
+    escaped_transform(
+      alpha,
+      '\\',
+      alt((
+        value(&b"\\"[..], tag("\\")),
+        value(&b"\""[..], tag("\"")),
+        value(&b"\n"[..], tag("n")),
+      )),
+    )
+    .map(to_s)
+    .parse(i)
   }
 
   assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], String::from("abcd"))));
@@ -191,17 +185,16 @@ fn complete_escape_transform() {
   );
 
   fn esc2(i: &[u8]) -> IResult<&[u8], String> {
-    map(
-      escaped_transform(
-        alpha,
-        '&',
-        alt((
-          value("è".as_bytes(), tag("egrave;")),
-          value("à".as_bytes(), tag("agrave;")),
-        )),
-      ),
-      to_s,
-    )(i)
+    escaped_transform(
+      alpha,
+      '&',
+      alt((
+        value("è".as_bytes(), tag("egrave;")),
+        value("à".as_bytes(), tag("agrave;")),
+      )),
+    )
+    .map(to_s)
+    .parse(i)
   }
   assert_eq!(
     esc2(&b"ab&egrave;DEF;"[..]),

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -77,7 +77,6 @@
 //!
 //! - [`cond`][cond]: Conditional combinator. Wraps another parser and calls it if the condition is met
 //! - [`Parser::flat_map`][crate::Parser::flat_map]: method to map a new parser from the output of the first parser, then apply that parser over the rest of the input
-//! - [`flat_map`][flat_map]: function variant of `Parser::flat_map`
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
 //! - [`map_opt`][map_opt]: Maps a function returning an `Option` on the output of a parser
 //! - [`map_res`][map_res]: Maps a function returning a `Result` on the output of a parser

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -923,6 +923,8 @@ where
 /// it will be able to convert the output value and the error value
 /// as long as the `Into` implementations are available
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::into`]
+///
 /// ```rust
 /// # use nom::IResult;
 /// use nom::combinator::into;
@@ -940,6 +942,7 @@ where
 /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::into")]
 pub fn into<I, O1, O2, E1, E2, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O2, E2>
 where
   O1: convert::Into<O2>,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -413,6 +413,8 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, 
 
 /// Creates a new parser from the output of the first parser, then apply that parser over the rest of the input.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::flat_map`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::bytes::take;
@@ -426,6 +428,7 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, 
 /// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::flat_map")]
 pub fn flat_map<I, O1, O2, E: ParseError<I>, F, G, H>(
   mut parser: F,
   mut applied_parser: G,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -354,6 +354,8 @@ where
 
 /// Applies a parser over the result of another one.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::and_then`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::character::digit1;
@@ -368,6 +370,7 @@ where
 /// assert_eq!(parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::and_then")]
 pub fn map_parser<I, O1, O2, E: ParseError<I>, F, G>(
   mut parser: F,
   mut applied_parser: G,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -79,7 +79,6 @@
 //! - [`Parser::flat_map`][crate::Parser::flat_map]: method to map a new parser from the output of the first parser, then apply that parser over the rest of the input
 //! - [`flat_map`][flat_map]: function variant of `Parser::flat_map`
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
-//! - [`map`][map]: function variant of `Parser::map`
 //! - [`map_opt`][map_opt]: Maps a function returning an `Option` on the output of a parser
 //! - [`map_res`][map_res]: Maps a function returning a `Result` on the output of a parser
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
@@ -836,6 +835,7 @@ where
 /// Returned tuple is of the format `(consumed input, produced output)`.
 ///
 /// ```rust
+/// # use nom::prelude::*;
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::{consumed, value, recognize, map};
 /// use nom::character::{char, alpha1};
@@ -857,10 +857,10 @@ where
 /// // the first output (representing the consumed input)
 /// // should be the same as that of the `recognize` parser.
 /// let mut recognize_parser = recognize(inner_parser);
-/// let mut consumed_parser = map(consumed(inner_parser), |(consumed, output)| consumed);
+/// let mut consumed_parser = consumed(inner_parser).map(|(consumed, output)| consumed);
 ///
-/// assert_eq!(recognize_parser("1234"), consumed_parser("1234"));
-/// assert_eq!(recognize_parser("abcd"), consumed_parser("abcd"));
+/// assert_eq!(recognize_parser("1234"), consumed_parser.parse("1234"));
+/// assert_eq!(recognize_parser("abcd"), consumed_parser.parse("abcd"));
 /// # }
 /// ```
 pub fn consumed<I, O, F, E>(

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -220,6 +220,8 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for MutParser<'p, P> {
 
 /// Maps a function on the result of a parser.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::map`]
+///
 /// ```rust
 /// use nom::{Err,error::ErrorKind, IResult,Parser};
 /// use nom::character::digit1;
@@ -235,6 +237,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for MutParser<'p, P> {
 /// assert_eq!(parser.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::map")]
 pub fn map<I, O1, O2, E, F, G>(mut parser: F, mut f: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
   F: Parser<I, O1, E>,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -78,6 +78,7 @@
 //! - [`cond`][cond]: Conditional combinator. Wraps another parser and calls it if the condition is met
 //! - [`Parser::flat_map`][crate::Parser::flat_map]: method to map a new parser from the output of the first parser, then apply that parser over the rest of the input
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
+//! - [`Parser::and_then`][crate::Parser::and_then]: Applies a second parser over the output of the first one
 //! - [`map_opt`][map_opt]: Maps a function returning an `Option` on the output of a parser
 //! - [`map_res`][map_res]: Maps a function returning a `Result` on the output of a parser
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -7,6 +7,7 @@ use crate::input::Streaming;
 #[cfg(feature = "alloc")]
 use crate::lib::std::boxed::Box;
 use crate::number::u8;
+use crate::Parser;
 use crate::{Err, IResult, Needed};
 
 macro_rules! assert_parse(
@@ -119,6 +120,15 @@ fn test_flat_map() {
   let input: &[u8] = &[3, 100, 101, 102, 103, 104][..];
   assert_parse!(
     flat_map(u8, take)(input),
+    Ok((&[103, 104][..], &[100, 101, 102][..]))
+  );
+}
+
+#[test]
+fn test_parser_flat_map() {
+  let input: &[u8] = &[3, 100, 101, 102, 103, 104][..];
+  assert_parse!(
+    u8.flat_map(take).parse(input),
     Ok((&[103, 104][..], &[100, 101, 102][..]))
   );
 }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -156,6 +156,15 @@ fn test_map_parser() {
 }
 
 #[test]
+fn test_parser_map_parser() {
+  let input: &[u8] = &[100, 101, 102, 103, 104][..];
+  assert_parse!(
+    take(4usize).and_then(take(2usize)).parse(input),
+    Ok((&[104][..], &[100, 101][..]))
+  );
+}
+
+#[test]
 fn test_all_consuming() {
   let input: &[u8] = &[100, 101, 102][..];
   assert_parse!(

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -117,6 +117,7 @@ fn custom_error(input: &[u8]) -> IResult<&[u8], &[u8], CustomError> {
 
 #[test]
 fn test_flat_map() {
+  #![allow(deprecated)]
   let input: &[u8] = &[3, 100, 101, 102, 103, 104][..];
   assert_parse!(
     flat_map(u8, take)(input),

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -226,6 +226,21 @@ fn test_into() {
 }
 
 #[test]
+#[cfg(feature = "std")]
+fn test_parser_into() {
+  use crate::bytes::take;
+  use crate::{
+    error::{Error, ParseError},
+    Err,
+  };
+
+  let mut parser = Parser::into(take::<_, _, Error<_>, false>(3u8));
+  let result: IResult<&[u8], Vec<u8>> = parser.parse(&b"abcdefg"[..]);
+
+  assert_eq!(result, Ok((&b"defg"[..], vec![97, 98, 99])));
+}
+
+#[test]
 fn opt_test() {
   fn opt_abcd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Option<&[u8]>> {
     opt(tag("abcd"))(i)

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -215,6 +215,7 @@ fn test_verify_alloc() {
 #[test]
 #[cfg(feature = "std")]
 fn test_into() {
+  #![allow(deprecated)]
   use crate::bytes::take;
   use crate::{
     error::{Error, ParseError},

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -199,7 +199,7 @@ fn test_verify_ref() {
 #[cfg(feature = "alloc")]
 fn test_verify_alloc() {
   use crate::bytes::take;
-  let mut parser1 = verify(map(take(3u8), |s: &[u8]| s.to_vec()), |s: &[u8]| {
+  let mut parser1 = verify(take(3u8).map(|s: &[u8]| s.to_vec()), |s: &[u8]| {
     s == &b"abc"[..]
   });
 

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -149,6 +149,7 @@ fn test_map_opt() {
 
 #[test]
 fn test_map_parser() {
+  #![allow(deprecated)]
   let input: &[u8] = &[100, 101, 102, 103, 104][..];
   assert_parse!(
     map_parser(take(4usize), take(2usize))(input),

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -926,6 +926,7 @@ where
 /// * `f` The parser to apply to obtain the count.
 /// * `g` The parser to apply repeatedly.
 /// ```rust
+/// # use nom::prelude::*;
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
 /// use nom::number::u8;
 /// use nom::multi::length_count;
@@ -933,7 +934,7 @@ where
 /// use nom::combinator::map;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-///   length_count(map(u8, |i| {
+///   length_count(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i
 ///   }), tag("abc"))(s)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -462,6 +462,9 @@ pub trait Parser<I, O, E> {
   }
 
   /// Applies a second parser over the input if the first one failed
+  ///
+  /// **WARNING:** Deprecated, replaced with [`nom::branch::alt`][crate::branch::alt]
+  #[deprecated(since = "8.0.0", note = "Replaced with `nom::branch::alt")]
   fn or<G>(self, g: G) -> Or<Self, G>
   where
     G: Parser<I, O, E>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -450,6 +450,9 @@ pub trait Parser<I, O, E> {
   }
 
   /// Applies a second parser after the first one, return their results as a tuple
+  ///
+  /// **WARNING:** Deprecated, replaced with [`nom::sequence::tuple`][crate::sequence::tuple]
+  #[deprecated(since = "8.0.0", note = "Replaced with `nom::sequence::tuple")]
   fn and<G, O2>(self, g: G) -> And<Self, G>
   where
     G: Parser<I, O2, E>,

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -3,11 +3,12 @@ use std::fmt::{Debug, Display, Formatter};
 
 use std::str::FromStr;
 
+use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::tag,
   character::{digit1 as digit, multispace0 as multispace},
-  combinator::{map, map_res},
+  combinator::map_res,
   multi::many0,
   sequence::{delimited, preceded},
   IResult,
@@ -61,17 +62,14 @@ impl Debug for Expr {
 fn parens(i: &str) -> IResult<&str, Expr> {
   delimited(
     multispace,
-    delimited(tag("("), map(expr, |e| Expr::Paren(Box::new(e))), tag(")")),
+    delimited(tag("("), expr.map(|e| Expr::Paren(Box::new(e))), tag(")")),
     multispace,
   )(i)
 }
 
 fn factor(i: &str) -> IResult<&str, Expr> {
   alt((
-    map(
-      map_res(delimited(multispace, digit, multispace), FromStr::from_str),
-      Expr::Value,
-    ),
+    map_res(delimited(multispace, digit, multispace), FromStr::from_str).map(Expr::Value),
     parens,
   ))(i)
 }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,7 +1,8 @@
 use nom::branch::alt;
 use nom::bytes::tag;
 use nom::character::digit1 as digit;
-use nom::combinator::{map, map_res, opt, recognize};
+use nom::combinator::{map_res, opt, recognize};
+use nom::prelude::*;
 use nom::sequence::{delimited, pair};
 use nom::IResult;
 
@@ -18,15 +19,14 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
 }
 
 fn float(i: &[u8]) -> IResult<&[u8], f32> {
-  map(
-    pair(opt(alt((tag("+"), tag("-")))), unsigned_float),
-    |(sign, value)| {
+  pair(opt(alt((tag("+"), tag("-")))), unsigned_float)
+    .map(|(sign, value)| {
       sign
         .and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
         .unwrap_or(1f32)
         * value
-    },
-  )(i)
+    })
+    .parse(i)
 }
 
 #[test]

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -23,9 +23,10 @@ pub fn take_char(input: &[u8]) -> IResult<&[u8], char> {
 mod parse_int {
   use nom::input::HexDisplay;
   use nom::input::Streaming;
+  use nom::prelude::*;
   use nom::{
     character::{digit1 as digit, space1 as space},
-    combinator::{complete, map, opt},
+    combinator::{complete, opt},
     multi::many0,
     IResult,
   };
@@ -38,16 +39,18 @@ mod parse_int {
   fn spaces_or_int(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i32> {
     println!("{}", input.to_hex(8));
     let (i, _) = opt(complete(space))(input)?;
-    let (i, res) = map(complete(digit), |x| {
-      println!("x: {:?}", x);
-      let result = str::from_utf8(x).unwrap();
-      println!("Result: {}", result);
-      println!("int is empty?: {}", x.is_empty());
-      match result.parse() {
-        Ok(i) => i,
-        Err(e) => panic!("UH OH! NOT A DIGIT! {:?}", e),
-      }
-    })(i)?;
+    let (i, res) = complete(digit)
+      .map(|x| {
+        println!("x: {:?}", x);
+        let result = str::from_utf8(x).unwrap();
+        println!("Result: {}", result);
+        println!("int is empty?: {}", x.is_empty());
+        match result.parse() {
+          Ok(i) => i,
+          Err(e) => panic!("UH OH! NOT A DIGIT! {:?}", e),
+        }
+      })
+      .parse(i)?;
 
     Ok((i, res))
   }

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
 use nom::input::Streaming;
+use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::{tag, take},
-  combinator::{map, map_res},
+  combinator::map_res,
   error::ErrorKind,
   multi::many0,
   number::{be_f32, be_u16, be_u32, be_u64},
@@ -281,12 +282,12 @@ fn unknown_box_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4Box
 
 fn box_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
   alt((
-    map(tag("ftyp"), |_| MP4BoxType::Ftyp),
-    map(tag("moov"), |_| MP4BoxType::Moov),
-    map(tag("mdat"), |_| MP4BoxType::Mdat),
-    map(tag("free"), |_| MP4BoxType::Free),
-    map(tag("skip"), |_| MP4BoxType::Skip),
-    map(tag("wide"), |_| MP4BoxType::Wide),
+    tag("ftyp").map(|_| MP4BoxType::Ftyp),
+    tag("moov").map(|_| MP4BoxType::Moov),
+    tag("mdat").map(|_| MP4BoxType::Mdat),
+    tag("free").map(|_| MP4BoxType::Free),
+    tag("skip").map(|_| MP4BoxType::Skip),
+    tag("wide").map(|_| MP4BoxType::Wide),
     unknown_box_type,
   ))(input)
 }
@@ -296,15 +297,15 @@ fn box_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
 // or split into multiple alt parsers if it gets slow
 fn moov_type(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, MP4BoxType> {
   alt((
-    map(tag("mdra"), |_| MP4BoxType::Mdra),
-    map(tag("dref"), |_| MP4BoxType::Dref),
-    map(tag("cmov"), |_| MP4BoxType::Cmov),
-    map(tag("rmra"), |_| MP4BoxType::Rmra),
-    map(tag("iods"), |_| MP4BoxType::Iods),
-    map(tag("mvhd"), |_| MP4BoxType::Mvhd),
-    map(tag("clip"), |_| MP4BoxType::Clip),
-    map(tag("trak"), |_| MP4BoxType::Trak),
-    map(tag("udta"), |_| MP4BoxType::Udta),
+    tag("mdra").map(|_| MP4BoxType::Mdra),
+    tag("dref").map(|_| MP4BoxType::Dref),
+    tag("cmov").map(|_| MP4BoxType::Cmov),
+    tag("rmra").map(|_| MP4BoxType::Rmra),
+    tag("iods").map(|_| MP4BoxType::Iods),
+    tag("mvhd").map(|_| MP4BoxType::Mvhd),
+    tag("clip").map(|_| MP4BoxType::Clip),
+    tag("trak").map(|_| MP4BoxType::Trak),
+    tag("udta").map(|_| MP4BoxType::Udta),
   ))(input)
 }
 

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -5,17 +5,17 @@ use std::str;
 
 use nom::bytes::is_not;
 use nom::character::char;
-use nom::combinator::{map, map_res};
+use nom::combinator::map_res;
 use nom::multi::fold_many0;
+use nom::prelude::*;
 use nom::sequence::delimited;
 use nom::IResult;
 
 fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
   move |input| {
-    map(
-      map_res(is_not(" \t\r\n"), str::from_utf8),
-      ToString::to_string,
-    )(input)
+    map_res(is_not(" \t\r\n"), str::from_utf8)
+      .map(ToString::to_string)
+      .parse(input)
   }
 }
 


### PR DESCRIPTION
Some parsers are duplicated between `Parser` and `nom::combinator`.  This consolidates them, to one or the other.  The guiding principle is that items related to the grammar are freestanding while dealing with outputs and errors is on `Parser`.

Some items for considering renaming:
- `Parser::and_then`: this is confusing
- `Parser::into`: ambiguous with `Into::into`, requiring being qualified