### PR TITLE
feat: Move non-grammar combinators to `Parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ error prone plumbing.
 [Hexadecimal color](https://developer.mozilla.org/en-US/docs/Web/CSS/color) parser:
 
 ```rust
-extern crate nom;
+use nom::prelude::*;
 use nom::{
   IResult,
   bytes::complete::{tag, take_while_m_n},
-  combinator::map_res,
   sequence::tuple
 };
 
@@ -64,10 +63,7 @@ fn is_hex_digit(c: char) -> bool {
 }
 
 fn hex_primary(input: &str) -> IResult<&str, u8> {
-  map_res(
-    take_while_m_n(2, 2, is_hex_digit),
-    from_hex
-  )(input)
+  take_while_m_n(2, 2, is_hex_digit).map_res(from_hex).parse(input)
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -6,7 +6,7 @@ use nom::{
   bytes::{escaped, tag, take_while},
   character::{alphanumeric1 as alphanumeric, char, f64, one_of},
   combinator::{cut, opt},
-  error::{context, convert_error, ContextError, ErrorKind, ParseError, VerboseError},
+  error::{convert_error, ContextError, ErrorKind, ParseError, VerboseError},
   multi::separated_list0,
   sequence::{delimited, preceded, separated_pair, terminated},
   Err, IResult,
@@ -94,10 +94,9 @@ fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {
 fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-  context(
-    "string",
-    preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
-  )(i)
+  preceded(char('\"'), cut(terminated(parse_str, char('\"'))))
+    .context("string")
+    .parse(i)
 }
 
 /// some combinators, like `separated_list0` or `many0`, will call a parser repeatedly,
@@ -107,16 +106,15 @@ fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, Vec<JsonValue>, E> {
-  context(
-    "array",
-    preceded(
-      char('['),
-      cut(terminated(
-        separated_list0(preceded(sp, char(',')), json_value),
-        preceded(sp, char(']')),
-      )),
-    ),
-  )(i)
+  preceded(
+    char('['),
+    cut(terminated(
+      separated_list0(preceded(sp, char(',')), json_value),
+      preceded(sp, char(']')),
+    )),
+  )
+  .context("array")
+  .parse(i)
 }
 
 fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -132,21 +130,20 @@ fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, HashMap<String, JsonValue>, E> {
-  context(
-    "map",
-    preceded(
-      char('{'),
-      cut(terminated(
-        separated_list0(preceded(sp, char(',')), key_value).map(|tuple_vec| {
-          tuple_vec
-            .into_iter()
-            .map(|(k, v)| (String::from(k), v))
-            .collect()
-        }),
-        preceded(sp, char('}')),
-      )),
-    ),
-  )(i)
+  preceded(
+    char('{'),
+    cut(terminated(
+      separated_list0(preceded(sp, char(',')), key_value).map(|tuple_vec| {
+        tuple_vec
+          .into_iter()
+          .map(|(k, v)| (String::from(k), v))
+          .collect()
+      }),
+      preceded(sp, char('}')),
+    )),
+  )
+  .context("map")
+  .parse(i)
 }
 
 /// here, we apply the space parser before trying to parse a value

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -5,7 +5,7 @@ use nom::{
   branch::alt,
   bytes::{escaped, tag, take_while},
   character::{alphanumeric1 as alphanumeric, char, f64, one_of},
-  combinator::{cut, opt, value},
+  combinator::{cut, opt},
   error::{context, convert_error, ContextError, ErrorKind, ParseError, VerboseError},
   multi::separated_list0,
   sequence::{delimited, preceded, separated_pair, terminated},
@@ -65,11 +65,11 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 fn boolean<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, bool, E> {
   // This is a parser that returns `true` if it sees the string "true", and
   // an error otherwise
-  let parse_true = value(true, tag("true"));
+  let parse_true = tag("true").value(true);
 
   // This is a parser that returns `false` if it sees the string "false", and
   // an error otherwise
-  let parse_false = value(false, tag("false"));
+  let parse_false = tag("false").value(false);
 
   // `alt` combines the two parsers. It returns the result of the first
   // successful parser, or an error
@@ -77,7 +77,7 @@ fn boolean<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, bool,
 }
 
 fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {
-  value((), tag("null"))(input)
+  tag("null").value(()).parse(input)
 }
 
 /// this parser combines the previous `parse_str` parser, that recognizes the

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -6,7 +6,7 @@ use nom::{
   bytes::{escaped, tag, take_while},
   character::{alphanumeric1 as alphanumeric, char, f64, one_of},
   combinator::cut,
-  error::{context, ParseError},
+  error::ParseError,
   multi::separated_list0,
   sequence::{preceded, separated_pair, terminated},
   IResult,
@@ -226,10 +226,9 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 }
 
 fn string<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
-  context(
-    "string",
-    preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
-  )(i)
+  preceded(char('\"'), cut(terminated(parse_str, char('\"'))))
+    .context("string")
+    .parse(i)
 }
 
 fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
@@ -237,16 +236,15 @@ fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
 }
 
 fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
-  context(
-    "array",
-    preceded(
-      char('['),
-      cut(terminated(
-        separated_list0(preceded(sp, char(',')), value).map(|_| ()),
-        preceded(sp, char(']')),
-      )),
-    ),
-  )(i)
+  preceded(
+    char('['),
+    cut(terminated(
+      separated_list0(preceded(sp, char(',')), value).map(|_| ()),
+      preceded(sp, char(']')),
+    )),
+  )
+  .context("array")
+  .parse(i)
 }
 
 fn key_value<'a>(i: &'a str) -> IResult<&'a str, (&'a str, ())> {
@@ -254,16 +252,15 @@ fn key_value<'a>(i: &'a str) -> IResult<&'a str, (&'a str, ())> {
 }
 
 fn hash<'a>(i: &'a str) -> IResult<&'a str, ()> {
-  context(
-    "map",
-    preceded(
-      char('{'),
-      cut(terminated(
-        separated_list0(preceded(sp, char(',')), key_value).map(|_| ()),
-        preceded(sp, char('}')),
-      )),
-    ),
-  )(i)
+  preceded(
+    char('{'),
+    cut(terminated(
+      separated_list0(preceded(sp, char(',')), key_value).map(|_| ()),
+      preceded(sp, char('}')),
+    )),
+  )
+  .context("map")
+  .parse(i)
 }
 
 fn value<'a>(i: &'a str) -> IResult<&'a str, ()> {

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -9,7 +9,7 @@ use nom::{
   bytes::tag,
   character::{alpha1, char, digit1, multispace0, multispace1, one_of},
   combinator::{cut, opt},
-  error::{context, VerboseError},
+  error::VerboseError,
   multi::many0,
   sequence::{delimited, preceded, terminated, tuple},
   IResult, Parser,
@@ -110,7 +110,8 @@ fn parse_bool<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
 /// Put plainly: `preceded(tag(":"), cut(alpha1))` means that once we see the `:`
 /// character, we have to see one or more alphabetic chararcters or the input is invalid.
 fn parse_keyword<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
-  context("keyword", preceded(tag(":"), cut(alpha1)))
+  preceded(tag(":"), cut(alpha1))
+    .context("keyword")
     .map(|sym_str: &str| Atom::Keyword(sym_str.to_string()))
     .parse(i)
 }
@@ -155,7 +156,7 @@ where
   delimited(
     char('('),
     preceded(multispace0, inner),
-    context("closing paren", cut(preceded(multispace0, char(')')))),
+    cut(preceded(multispace0, char(')'))).context("closing paren"),
   )
 }
 
@@ -182,27 +183,25 @@ fn parse_application<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a 
 /// In fact, we define our parser as if `Expr::If` was defined with an Option in it,
 /// we have the `opt` combinator which fits very nicely here.
 fn parse_if<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
-  let if_inner = context(
-    "if expression",
-    preceded(
-      // here to avoid ambiguity with other names starting with `if`, if we added
-      // variables to our language, we say that if must be terminated by at least
-      // one whitespace character
-      terminated(tag("if"), multispace1),
-      cut(tuple((parse_expr, parse_expr, opt(parse_expr)))),
-    )
-    .map(|(pred, true_branch, maybe_false_branch)| {
-      if let Some(false_branch) = maybe_false_branch {
-        Expr::IfElse(
-          Box::new(pred),
-          Box::new(true_branch),
-          Box::new(false_branch),
-        )
-      } else {
-        Expr::If(Box::new(pred), Box::new(true_branch))
-      }
-    }),
-  );
+  let if_inner = preceded(
+    // here to avoid ambiguity with other names starting with `if`, if we added
+    // variables to our language, we say that if must be terminated by at least
+    // one whitespace character
+    terminated(tag("if"), multispace1),
+    cut(tuple((parse_expr, parse_expr, opt(parse_expr)))),
+  )
+  .map(|(pred, true_branch, maybe_false_branch)| {
+    if let Some(false_branch) = maybe_false_branch {
+      Expr::IfElse(
+        Box::new(pred),
+        Box::new(true_branch),
+        Box::new(false_branch),
+      )
+    } else {
+      Expr::If(Box::new(pred), Box::new(true_branch))
+    }
+  })
+  .context("if expression");
   s_exp(if_inner)(i)
 }
 
@@ -215,7 +214,8 @@ fn parse_quote<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> 
   // this should look very straight-forward after all we've done:
   // we find the `'` (quote) character, use cut to say that we're unambiguously
   // looking for an s-expression of 0 or more expressions, and then parse them
-  context("quote", preceded(tag("'"), cut(s_exp(many0(parse_expr)))))
+  preceded(tag("'"), cut(s_exp(many0(parse_expr))))
+    .context("quote")
     .map(|exprs| Expr::Quote(exprs))
     .parse(i)
 }

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -8,7 +8,7 @@ use nom::{
   branch::alt,
   bytes::tag,
   character::{alpha1, char, digit1, multispace0, multispace1, one_of},
-  combinator::{cut, map_res, opt},
+  combinator::{cut, opt},
   error::{context, VerboseError},
   multi::many0,
   sequence::{delimited, preceded, terminated, tuple},
@@ -119,9 +119,7 @@ fn parse_keyword<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>
 /// of digits but ending the program if it doesn't fit into an i32.
 fn parse_num<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
   alt((
-    map_res(digit1, |digit_str: &str| {
-      digit_str.parse::<i32>().map(Atom::Num)
-    }),
+    digit1.map_res(|digit_str: &str| digit_str.parse::<i32>().map(Atom::Num)),
     preceded(tag("-"), digit1)
       .map(|digit_str: &str| Atom::Num(-1 * digit_str.parse::<i32>().unwrap())),
   ))(i)

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -14,7 +14,7 @@
 use nom::branch::alt;
 use nom::bytes::{is_not, take_while_m_n};
 use nom::character::{char, multispace1};
-use nom::combinator::{map_opt, map_res, value, verify};
+use nom::combinator::{map_opt, value, verify};
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -49,7 +49,7 @@ where
   // `map_res` takes the result of a parser and applies a function that returns
   // a Result. In this case we take the hex bytes from parse_hex and attempt to
   // convert them to a u32.
-  let parse_u32 = map_res(parse_delimited_hex, move |hex| u32::from_str_radix(hex, 16));
+  let parse_u32 = parse_delimited_hex.map_res(move |hex| u32::from_str_radix(hex, 16));
 
   // map_opt is like map_res, but it takes an Option instead of a Result. If
   // the function returns None, map_opt returns an error. In this case, because

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -14,7 +14,7 @@
 use nom::branch::alt;
 use nom::bytes::{is_not, take_while_m_n};
 use nom::character::{char, multispace1};
-use nom::combinator::{map_opt, value, verify};
+use nom::combinator::{value, verify};
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -55,7 +55,9 @@ where
   // the function returns None, map_opt returns an error. In this case, because
   // not all u32 values are valid unicode code points, we have to fallibly
   // convert to char with from_u32.
-  map_opt(parse_u32, |value| std::char::from_u32(value))(input)
+  parse_u32
+    .map_opt(|value| std::char::from_u32(value))
+    .parse(input)
 }
 
 /// Parse an escaped character: \n, \t, \r, \u{00AC}, etc.

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -14,7 +14,7 @@
 use nom::branch::alt;
 use nom::bytes::{is_not, take_while_m_n};
 use nom::character::{char, multispace1};
-use nom::combinator::{value, verify};
+use nom::combinator::value;
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -105,7 +105,7 @@ fn parse_literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str,
   // the parser. The verification function accepts out output only if it
   // returns true. In this case, we want to ensure that the output of is_not
   // is non-empty.
-  verify(not_quote_slash, |s: &str| !s.is_empty())(input)
+  not_quote_slash.verify(|s: &str| !s.is_empty()).parse(input)
 }
 
 /// A string fragment contains a fragment of a string being parsed: either

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -14,7 +14,6 @@
 use nom::branch::alt;
 use nom::bytes::{is_not, take_while_m_n};
 use nom::character::{char, multispace1};
-use nom::combinator::value;
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -75,14 +74,14 @@ where
       // parser (the second argument) succeeds. In these cases, it looks for
       // the marker characters (n, r, t, etc) and returns the matching
       // character (\n, \r, \t, etc).
-      value('\n', char('n')),
-      value('\r', char('r')),
-      value('\t', char('t')),
-      value('\u{08}', char('b')),
-      value('\u{0C}', char('f')),
-      value('\\', char('\\')),
-      value('/', char('/')),
-      value('"', char('"')),
+      char('n').value('\n'),
+      char('r').value('\r'),
+      char('t').value('\t'),
+      char('b').value('\u{08}'),
+      char('f').value('\u{0C}'),
+      char('\\').value('\\'),
+      char('/').value('/'),
+      char('"').value('"'),
     )),
   )(input)
 }
@@ -129,7 +128,7 @@ where
     // of that parser.
     parse_literal.map(StringFragment::Literal),
     parse_escaped_char.map(StringFragment::EscapedChar),
-    value(StringFragment::EscapedWS, parse_escaped_whitespace),
+    parse_escaped_whitespace.value(StringFragment::EscapedWS),
   ))(input)
 }
 

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -188,28 +188,28 @@
 //! If you want it to return the integer value instead, use map:
 //!
 //! ```rust
+//! use nom::prelude::*;
 //! use nom::{
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::{map_res, recognize},
+//!   combinator::{recognize},
 //!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //!   bytes::complete::tag,
 //! };
 //!
 //! fn hexadecimal_value(input: &str) -> IResult<&str, i64> {
-//!   map_res(
-//!     preceded(
-//!       alt((tag("0x"), tag("0X"))),
-//!       recognize(
-//!         many1(
-//!           terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
-//!         )
+//!   preceded(
+//!     alt((tag("0x"), tag("0X"))),
+//!     recognize(
+//!       many1(
+//!         terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
 //!       )
-//!     ),
+//!     )
+//!   ).map_res(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
-//!   )(input)
+//!   ).parse(input)
 //! }
 //! ```
 //!

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -109,23 +109,23 @@
 //! letters and numbers may be parsed like this:
 //!
 //! ```rust
+//! use nom::prelude::*;
 //! use nom::{
 //!   IResult,
 //!   branch::alt,
 //!   multi::many0_count,
-//!   combinator::recognize,
 //!   sequence::pair,
 //!   character::complete::{alpha1, alphanumeric1},
 //!   bytes::complete::tag,
 //! };
 //!
 //! pub fn identifier(input: &str) -> IResult<&str, &str> {
-//!   recognize(
-//!     pair(
-//!       alt((alpha1, tag("_"))),
-//!       many0_count(alt((alphanumeric1, tag("_"))))
-//!     )
-//!   )(input)
+//!   pair(
+//!     alt((alpha1, tag("_"))),
+//!     many0_count(alt((alphanumeric1, tag("_"))))
+//!   )
+//!      .recognize()
+//!      .parse(input)
 //! }
 //! ```
 //!
@@ -164,7 +164,6 @@
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::recognize,
 //!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //!   bytes::complete::tag,
@@ -173,11 +172,9 @@
 //! fn hexadecimal(input: &str) -> IResult<&str, &str> { // <'a, E: ParseError<&'a str>>
 //!   preceded(
 //!     alt((tag("0x"), tag("0X"))),
-//!     recognize(
-//!       many1(
-//!         terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
-//!       )
-//!     )
+//!     many1(
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
+//!     ).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -190,7 +187,6 @@
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::{recognize},
 //!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //!   bytes::complete::tag,
@@ -199,11 +195,9 @@
 //! fn hexadecimal_value(input: &str) -> IResult<&str, i64> {
 //!   preceded(
 //!     alt((tag("0x"), tag("0X"))),
-//!     recognize(
-//!       many1(
-//!         terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
-//!       )
-//!     )
+//!     many1(
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
+//!     ).recognize()
 //!   ).map_res(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
 //!   ).parse(input)
@@ -217,7 +211,6 @@
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::recognize,
 //!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //!   bytes::complete::tag,
@@ -226,11 +219,9 @@
 //! fn octal(input: &str) -> IResult<&str, &str> {
 //!   preceded(
 //!     alt((tag("0o"), tag("0O"))),
-//!     recognize(
-//!       many1(
-//!         terminated(one_of("01234567"), many0(char('_')))
-//!       )
-//!     )
+//!     many1(
+//!       terminated(one_of("01234567"), many0(char('_')))
+//!     ).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -242,7 +233,6 @@
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::recognize,
 //!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //!   bytes::complete::tag,
@@ -251,11 +241,9 @@
 //! fn binary(input: &str) -> IResult<&str, &str> {
 //!   preceded(
 //!     alt((tag("0b"), tag("0B"))),
-//!     recognize(
-//!       many1(
-//!         terminated(one_of("01"), many0(char('_')))
-//!       )
-//!     )
+//!     many1(
+//!       terminated(one_of("01"), many0(char('_')))
+//!     ).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -263,20 +251,20 @@
 //! #### Decimal
 //!
 //! ```rust
+//! use nom::prelude::*;
 //! use nom::{
 //!   IResult,
 //!   multi::{many0, many1},
-//!   combinator::recognize,
 //!   sequence::terminated,
 //!   character::complete::{char, one_of},
 //! };
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
-//!   recognize(
-//!     many1(
-//!       terminated(one_of("0123456789"), many0(char('_')))
-//!     )
-//!   )(input)
+//!   many1(
+//!     terminated(one_of("0123456789"), many0(char('_')))
+//!   )
+//!     .recognize()
+//!     .parse(input)
 //! }
 //! ```
 //!
@@ -289,7 +277,7 @@
 //!   IResult,
 //!   branch::alt,
 //!   multi::{many0, many1},
-//!   combinator::{opt, recognize},
+//!   combinator::opt,
 //!   sequence::{preceded, terminated, tuple},
 //!   character::complete::{char, one_of},
 //! };
@@ -297,47 +285,41 @@
 //! fn float(input: &str) -> IResult<&str, &str> {
 //!   alt((
 //!     // Case one: .42
-//!     recognize(
-//!       tuple((
-//!         char('.'),
-//!         decimal,
-//!         opt(tuple((
-//!           one_of("eE"),
-//!           opt(one_of("+-")),
-//!           decimal
-//!         )))
-//!       ))
-//!     )
-//!     , // Case two: 42e42 and 42.42e42
-//!     recognize(
-//!       tuple((
-//!         decimal,
-//!         opt(preceded(
-//!           char('.'),
-//!           decimal,
-//!         )),
+//!     tuple((
+//!       char('.'),
+//!       decimal,
+//!       opt(tuple((
 //!         one_of("eE"),
 //!         opt(one_of("+-")),
 //!         decimal
-//!       ))
-//!     )
-//!     , // Case three: 42. and 42.42
-//!     recognize(
-//!       tuple((
-//!         decimal,
+//!       )))
+//!     )).recognize()
+//!     , // Case two: 42e42 and 42.42e42
+//!     tuple((
+//!       decimal,
+//!       opt(preceded(
 //!         char('.'),
-//!         opt(decimal)
-//!       ))
-//!     )
+//!         decimal,
+//!       )),
+//!       one_of("eE"),
+//!       opt(one_of("+-")),
+//!       decimal
+//!     )).recognize()
+//!     , // Case three: 42. and 42.42
+//!     tuple((
+//!       decimal,
+//!       char('.'),
+//!       opt(decimal)
+//!     )).recognize()
 //!   ))(input)
 //! }
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
-//!   recognize(
-//!     many1(
-//!       terminated(one_of("0123456789"), many0(char('_')))
-//!     )
-//!   )(input)
+//!   many1(
+//!     terminated(one_of("0123456789"), many0(char('_')))
+//!   )
+//!     .recognize()
+//!     .parse(input)
 //! }
 //! ```
 //!

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -28,7 +28,6 @@
 //! use nom::{
 //!   IResult,
 //!   error::ParseError,
-//!   combinator::value,
 //!   sequence::delimited,
 //!   character::complete::multispace0,
 //! };
@@ -60,10 +59,10 @@
 //! output of `()`.
 //!
 //! ```rust
+//! use nom::prelude::*;
 //! use nom::{
 //!   IResult,
 //!   error::ParseError,
-//!   combinator::value,
 //!   sequence::pair,
 //!   bytes::complete::is_not,
 //!   character::complete::char,
@@ -71,10 +70,9 @@
 //!
 //! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E>
 //! {
-//!   value(
-//!     (), // Output is thrown away.
-//!     pair(char('%'), is_not("\n\r"))
-//!   )(i)
+//!   pair(char('%'), is_not("\n\r"))
+//!     .value(()) // Output is thrown away.
+//!     .parse(i)
 //! }
 //! ```
 //!
@@ -84,23 +82,22 @@
 //! and does not handle nested comments.
 //!
 //! ```rust
+//! use nom::prelude::*;
 //! use nom::{
 //!   IResult,
 //!   error::ParseError,
-//!   combinator::value,
 //!   sequence::tuple,
 //!   bytes::complete::{tag, take_until},
 //! };
 //!
 //! pub fn pinline_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E> {
-//!   value(
-//!     (), // Output is thrown away.
-//!     tuple((
-//!       tag("(*"),
-//!       take_until("*)"),
-//!       tag("*)")
-//!     ))
-//!   )(i)
+//!   tuple((
+//!     tag("(*"),
+//!     take_until("*)"),
+//!     tag("*)")
+//!   ))
+//!     .value(()) // Output is thrown away.
+//!     .parse(i)
 //! }
 //! ```
 //!

--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -196,24 +196,23 @@
 //!
 //! There are a few tools you can use to debug how code is generated.
 //!
-//! ## dbg_dmp
+//! ## dbg_err
 //!
-//! This function wraps a parser that accepts a `&[u8]` as input and
+//! This function wraps a parser that accepts byte-like input (bytes, str) and
 //! prints its hexdump if the child parser encountered an error:
 //!
 //! ```rust
-//! # use nom::IResult;
+//! use nom::prelude::*;
 //! use nom::bytes::complete::tag;
-//! use nom::error::dbg_dmp;
 //!
 //! fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   dbg_dmp(tag("abcd"), "tag")(i)
+//!   tag("abcd").dbg_err("tag").parse(i)
 //! }
 //!
 //! let a = &b"efghijkl"[..];
 //!
 //! // Will print the following message:
-//! // Error(Position(0, [101, 102, 103, 104, 105, 106, 107, 108])) at l.5 by ' tag ! ( "abcd" ) '
+//! // tag: Error(Position(0, [101, 102, 103, 104, 105, 106, 107, 108])):
 //! // 00000000        65 66 67 68 69 6a 6b 6c         efghijkl
 //! f(a);
 //! ```

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use crate::combinator::recognize;
 use crate::error::ErrorKind;
 use crate::input::AsChar;
 use crate::input::Streaming;
@@ -352,7 +351,9 @@ fn streaming_recognize() {
   };
 
   fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(delimited(tag("<!--"), take(5_usize), tag("-->")))(i)
+    delimited(tag("<!--"), take(5_usize), tag("-->"))
+      .recognize()
+      .parse(i)
   }
   let r = x(Streaming(&b"<!-- abc --> aaa"[..]));
   assert_eq!(r, Ok((Streaming(&b" aaa"[..]), &b"<!-- abc -->"[..])));
@@ -360,43 +361,43 @@ fn streaming_recognize() {
   let semicolon = &b";"[..];
 
   fn ya(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(alpha)(i)
+    alpha.recognize().parse(i)
   }
   let ra = ya(Streaming(&b"abc;"[..]));
   assert_eq!(ra, Ok((Streaming(semicolon), &b"abc"[..])));
 
   fn yd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(digit)(i)
+    digit.recognize().parse(i)
   }
   let rd = yd(Streaming(&b"123;"[..]));
   assert_eq!(rd, Ok((Streaming(semicolon), &b"123"[..])));
 
   fn yhd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(hex_digit)(i)
+    hex_digit.recognize().parse(i)
   }
   let rhd = yhd(Streaming(&b"123abcDEF;"[..]));
   assert_eq!(rhd, Ok((Streaming(semicolon), &b"123abcDEF"[..])));
 
   fn yod(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(oct_digit)(i)
+    oct_digit.recognize().parse(i)
   }
   let rod = yod(Streaming(&b"1234567;"[..]));
   assert_eq!(rod, Ok((Streaming(semicolon), &b"1234567"[..])));
 
   fn yan(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(alphanumeric)(i)
+    alphanumeric.recognize().parse(i)
   }
   let ran = yan(Streaming(&b"123abc;"[..]));
   assert_eq!(ran, Ok((Streaming(semicolon), &b"123abc"[..])));
 
   fn ys(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(space)(i)
+    space.recognize().parse(i)
   }
   let rs = ys(Streaming(&b" \t;"[..]));
   assert_eq!(rs, Ok((Streaming(semicolon), &b" \t"[..])));
 
   fn yms(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(multispace)(i)
+    multispace.recognize().parse(i)
   }
   let rms = yms(Streaming(&b" \t\r\n;"[..]));
   assert_eq!(rms, Ok((Streaming(semicolon), &b" \t\r\n"[..])));
@@ -590,7 +591,7 @@ fn streaming_recognize_take_while() {
     take_while(AsChar::is_alphanum)(i)
   }
   fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    recognize(x)(i)
+    x.recognize().parse(i)
   }
   assert_eq!(
     x(Streaming(&b"ab."[..])),

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -10,7 +10,7 @@ use crate::Err;
 use crate::IResult;
 use crate::Needed;
 #[cfg(feature = "alloc")]
-use crate::{branch::alt, combinator::value, lib::std::string::String, lib::std::vec::Vec};
+use crate::{branch::alt, lib::std::string::String, lib::std::vec::Vec};
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
@@ -145,9 +145,9 @@ fn complete_escape_transform() {
       alpha,
       '\\',
       alt((
-        value(&b"\\"[..], tag("\\")),
-        value(&b"\""[..], tag("\"")),
-        value(&b"\n"[..], tag("n")),
+        tag("\\").value(&b"\\"[..]),
+        tag("\"").value(&b"\""[..]),
+        tag("n").value(&b"\n"[..]),
       )),
     )
     .map(to_s)
@@ -189,8 +189,8 @@ fn complete_escape_transform() {
       alpha,
       '&',
       alt((
-        value("è".as_bytes(), tag("egrave;")),
-        value("à".as_bytes(), tag("agrave;")),
+        tag("egrave;").value("è".as_bytes()),
+        tag("agrave;").value("à".as_bytes()),
       )),
     )
     .map(to_s)
@@ -216,9 +216,9 @@ fn complete_escape_transform_str() {
       alpha,
       '\\',
       alt((
-        value("\\", tag("\\")),
-        value("\"", tag("\"")),
-        value("\n", tag("n")),
+        tag("\\").value("\\"),
+        tag("\"").value("\""),
+        tag("n").value("\n"),
       )),
     )(i)
   }
@@ -248,7 +248,7 @@ fn complete_escape_transform_str() {
     escaped_transform(
       alpha,
       '&',
-      alt((value("è", tag("egrave;")), value("à", tag("agrave;")))),
+      alt((tag("egrave;").value("è"), tag("agrave;").value("à"))),
     )(i)
   }
   assert_eq!(esc2("ab&egrave;DEF;"), Ok((";", String::from("abèDEF"))));
@@ -261,7 +261,7 @@ fn complete_escape_transform_str() {
     escaped_transform(
       alpha,
       '␛',
-      alt((value("\0", tag("0")), value("\n", tag("n")))),
+      alt((tag("0").value("\0"), tag("n").value("\n"))),
     )(i)
   }
   assert_eq!(esc3("a␛0bc␛n"), Ok(("", String::from("a\0bc\n"))));

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -632,22 +632,19 @@ where
 ///
 /// ## Parsing an integer
 ///
-/// You can use `digit1` in combination with [`map_res`] to parse an integer:
+/// You can use `digit1` in combination with [`Parser::map_res`][crate::Parser::map_res] to parse an integer:
 ///
 /// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::combinator::map_res;
+/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed, Parser};
 /// # use nom::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
-///   map_res(digit1, str::parse)(input)
+///   digit1.map_res(str::parse).parse(input)
 /// }
 ///
 /// assert_eq!(parser("416"), Ok(("", 416)));
 /// assert_eq!(parser("12b"), Ok(("b", 12)));
 /// assert!(parser("b").is_err());
 /// ```
-///
-/// [`map_res`]: crate::combinator::map_res
 #[inline(always)]
 pub fn digit1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1066,6 +1066,8 @@ where
 ///
 /// Returned tuple is of the format `(consumed input, produced output)`.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::with_recognized`] (output ordering is changed)
+///
 /// ```rust
 /// # use nom::prelude::*;
 /// # use nom::{Err,error::ErrorKind, IResult};
@@ -1095,6 +1097,10 @@ where
 /// assert_eq!(recognize_parser("abcd"), consumed_parser.parse("abcd"));
 /// # }
 /// ```
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `Parser::with_recognized (output ordering is changed)"
+)]
 pub fn consumed<I, O, F, E>(
   mut parser: F,
 ) -> impl FnMut(I) -> IResult<I, (<I as IntoOutput>::Output, O), E>

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -80,7 +80,7 @@
 //! - [`Parser::value`][crate::Parser::value]: method to replace the result of a parser
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
 //! - [`Parser::and_then`][crate::Parser::and_then]: Applies a second parser over the output of the first one
-//! - [`map_opt`][map_opt]: Maps a function returning an `Option` on the output of a parser
+//! - [`Parser::map_opt`][Parser::map_opt]: Maps a function returning an `Option` on the output of a parser
 //! - [`Parser::map_res`][Parser::map_res]: Maps a function returning a `Result` on the output of a parser
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
 //! - [`opt`][opt]: Make the underlying parser optional

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -85,7 +85,7 @@
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
 //! - [`opt`][opt]: Make the underlying parser optional
 //! - [`peek`][peek]: Returns a result without consuming the input
-//! - [`recognize`][recognize]: If the child parser was successful, return the consumed input as the produced value
+//! - [`Parser::recognize`][Parser::recognize]: If the child parser was successful, return the consumed input as the produced value
 //! - [`consumed`][consumed]: If the child parser was successful, return a tuple of the consumed input and the produced output.
 //! - [`Parser::verify`]: Returns the result of the child parser if it satisfies a verification function
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -280,6 +280,8 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> fo
 
 /// Applies a function returning a `Result` over the result of a parser.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::map_res`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::character::digit1;
@@ -298,6 +300,7 @@ impl<'a, I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> fo
 /// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
 pub fn map_res<I: Clone, O1, O2, E: FromExternalError<I, E2>, E2, F, G>(
   mut parser: F,
   mut f: G,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -86,7 +86,7 @@
 //! - [`opt`][opt]: Make the underlying parser optional
 //! - [`peek`][peek]: Returns a result without consuming the input
 //! - [`Parser::recognize`][Parser::recognize]: If the child parser was successful, return the consumed input as the produced value
-//! - [`consumed`][consumed]: If the child parser was successful, return a tuple of the consumed input and the produced output.
+//! - [`Parser::with_recognized`][Parser::with_recognized]: If the child parser was successful, return a tuple of the consumed input and the produced output.
 //! - [`Parser::verify`]: Returns the result of the child parser if it satisfies a verification function
 //!
 //! ## Error management and debugging

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -81,7 +81,7 @@
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
 //! - [`Parser::and_then`][crate::Parser::and_then]: Applies a second parser over the output of the first one
 //! - [`map_opt`][map_opt]: Maps a function returning an `Option` on the output of a parser
-//! - [`map_res`][map_res]: Maps a function returning a `Result` on the output of a parser
+//! - [`Parser::map_res`][Parser::map_res]: Maps a function returning a `Result` on the output of a parser
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input
 //! - [`opt`][opt]: Make the underlying parser optional
 //! - [`peek`][peek]: Returns a result without consuming the input

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -730,6 +730,8 @@ where
 
 /// Transforms Incomplete into `Error`.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::complete`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult, input::Streaming};
 /// use nom::bytes::take;
@@ -742,6 +744,7 @@ where
 /// assert_eq!(parser(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::complete")]
 pub fn complete<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
   F: Parser<I, O, E>,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -356,6 +356,8 @@ where
 
 /// Applies a function returning an `Option` over the result of a parser.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::map_opt`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::character::digit1;
@@ -374,6 +376,7 @@ where
 /// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
 pub fn map_opt<I: Clone, O1, O2, E: ParseError<I>, F, G>(
   mut parser: F,
   mut f: G,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -820,6 +820,8 @@ where
 /// The verification function takes as argument a reference to the output of the
 /// parser.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::map`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::verify;
@@ -833,6 +835,7 @@ where
 /// assert_eq!(parser("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::verify")]
 pub fn verify<I: Clone, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
   second: G,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -747,6 +747,33 @@ where
   }
 }
 
+/// Implementation of [`Parser::complete`]
+#[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
+pub struct Complete<F> {
+  f: F,
+}
+
+impl<F> Complete<F> {
+  pub(crate) fn new(f: F) -> Self {
+    Self { f }
+  }
+}
+
+impl<F, I, O, E> Parser<I, O, E> for Complete<F>
+where
+  I: Clone,
+  F: Parser<I, O, E>,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, input: I) -> IResult<I, O, E> {
+    let i = input.clone();
+    match (self.f).parse(input) {
+      Err(Err::Incomplete(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Complete))),
+      rest => rest,
+    }
+  }
+}
+
 /// Succeeds if all the input has been consumed by its child parser.
 ///
 /// ```rust

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -91,6 +91,7 @@
 //!
 //! ## Error management and debugging
 //!
+//! - [`Parser::context`: Add context to the error if the parser fails
 //! - [`dbg_dmp`][crate::error::dbg_dmp]: Prints a message and the input if the parser fails
 //!
 //! ## Text parsing

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -92,7 +92,7 @@
 //! ## Error management and debugging
 //!
 //! - [`Parser::context`]: Add context to the error if the parser fails
-//! - [`dbg_dmp`][crate::error::dbg_dmp]: Prints a message and the input if the parser fails
+//! - [`Parser::dbg_err`]: Prints a message and the input if the parser fails
 //!
 //! ## Text parsing
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -899,6 +899,8 @@ where
 
 /// Returns the provided value if the child parser succeeds.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::value`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::value;
@@ -911,6 +913,7 @@ where
 /// assert_eq!(parser("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::value")]
 pub fn value<I, O1: Clone, O2, E: ParseError<I>, F>(
   val: O1,
   mut parser: F,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -87,7 +87,7 @@
 //! - [`peek`][peek]: Returns a result without consuming the input
 //! - [`recognize`][recognize]: If the child parser was successful, return the consumed input as the produced value
 //! - [`consumed`][consumed]: If the child parser was successful, return a tuple of the consumed input and the produced output.
-//! - [`verify`][verify]: Returns the result of the child parser if it satisfies a verification function
+//! - [`Parser::verify`]: Returns the result of the child parser if it satisfies a verification function
 //!
 //! ## Error management and debugging
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -91,7 +91,7 @@
 //!
 //! ## Error management and debugging
 //!
-//! - [`Parser::context`: Add context to the error if the parser fails
+//! - [`Parser::context`]: Add context to the error if the parser fails
 //! - [`dbg_dmp`][crate::error::dbg_dmp]: Prints a message and the input if the parser fails
 //!
 //! ## Text parsing

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -71,7 +71,7 @@
 //! ## Streaming related
 //!
 //! - [`eof`][eof]: Returns its input if it is at the end of input data
-//! - [`complete`][complete()]: Replaces an `Incomplete` returned by the child parser with an `Error`
+//! - [`Parser::complete`][Parser::complete()]: Replaces an `Incomplete` returned by the child parser with an `Error`
 //!
 //! ## Modifiers
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -982,6 +982,8 @@ where
 
 /// If the child parser was successful, return the consumed input as produced value.
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::recognize`]
+///
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
 /// use nom::combinator::recognize;
@@ -995,6 +997,7 @@ where
 /// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
 /// # }
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::recognize")]
 pub fn recognize<I, O, E: ParseError<I>, F>(
   mut parser: F,
 ) -> impl FnMut(I) -> IResult<I, <I as IntoOutput>::Output, E>

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -198,6 +198,7 @@ fn test_all_consuming() {
 #[test]
 #[allow(unused)]
 fn test_verify_ref() {
+  #![allow(deprecated)]
   use crate::bytes::take;
 
   let mut parser1 = verify(take(3u8), |s: &[u8]| s == &b"abc"[..]);
@@ -216,6 +217,7 @@ fn test_verify_ref() {
 #[test]
 #[cfg(feature = "alloc")]
 fn test_verify_alloc() {
+  #![allow(deprecated)]
   use crate::bytes::take;
   let mut parser1 = verify(take(3u8).map(|s: &[u8]| s.to_vec()), |s: &[u8]| {
     s == &b"abc"[..]
@@ -327,6 +329,7 @@ fn not_test() {
 
 #[test]
 fn verify_test() {
+  #![allow(deprecated)]
   use crate::bytes::take;
 
   fn test(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -136,6 +136,7 @@ fn test_parser_flat_map() {
 
 #[test]
 fn test_map_opt() {
+  #![allow(deprecated)]
   let input: &[u8] = &[50][..];
   assert_parse!(
     map_opt(u8, |u| if u < 20 { Some(u) } else { None })(input),

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -148,6 +148,21 @@ fn test_map_opt() {
 }
 
 #[test]
+fn test_parser_map_opt() {
+  let input: &[u8] = &[50][..];
+  assert_parse!(
+    u8.map_opt(|u| if u < 20 { Some(u) } else { None })
+      .parse(input),
+    Err(Err::Error((&[50][..], ErrorKind::MapOpt)))
+  );
+  assert_parse!(
+    u8.map_opt(|u| if u > 20 { Some(u) } else { None })
+      .parse(input),
+    Ok((&[][..], 50))
+  );
+}
+
+#[test]
 fn test_map_parser() {
   #![allow(deprecated)]
   let input: &[u8] = &[100, 101, 102, 103, 104][..];

--- a/src/error.rs
+++ b/src/error.rs
@@ -697,6 +697,9 @@ use crate::{Err, IResult};
 /// Create a new error from an input position, a static string and an existing error.
 /// This is used mainly in the [context] combinator, to add user friendly information
 /// to errors when backtracking through a parse tree
+///
+/// **WARNING:** Deprecated, replaced with [`Parser::context`]
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::context")]
 pub fn context<I: Clone, E: ContextError<I>, F, O>(
   context: &'static str,
   mut f: F,

--- a/src/error.rs
+++ b/src/error.rs
@@ -453,17 +453,16 @@
 //! While you are writing your parsers, you will sometimes need to follow
 //! which part of the parser sees which part of the input.
 //!
-//! To that end, nom provides the `dbg_dmp` function that will observe
+//! To that end, nom provides the `dbg_err` function that will observe
 //! a parser's input and output, and print a hexdump of the input if there was an
 //! error. Here is what it could return:
 //!
 #![cfg_attr(feature = "std", doc = "```")]
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! # use nom::IResult;
-//! # use nom::error::dbg_dmp;
+//! use nom::prelude::*;
 //! # use nom::bytes::tag;
 //! fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!     dbg_dmp(tag("abcd"), "tag")(i)
+//!     tag("abcd").dbg_err("tag").parse(i)
 //! }
 //!
 //! let a = &b"efghijkl"[..];

--- a/src/error.rs
+++ b/src/error.rs
@@ -1074,6 +1074,8 @@ macro_rules! error_node_position(
 ///
 /// It also displays the input in hexdump format
 ///
+/// **WARNING:** Deprecated, replaced with [`Parser::dbg_err`]
+///
 /// ```rust
 /// use nom::{IResult, error::dbg_dmp, bytes::tag};
 ///
@@ -1088,6 +1090,7 @@ macro_rules! error_node_position(
 /// // 00000000        65 66 67 68 69 6a 6b 6c         efghijkl
 /// f(a);
 /// ```
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser::dbg_err")]
 #[cfg(feature = "std")]
 pub fn dbg_dmp<'a, F, O, E: std::fmt::Debug>(
   f: F,

--- a/src/input.rs
+++ b/src/input.rs
@@ -181,7 +181,7 @@ impl<const YES: bool> InputIsStreaming<YES> for crate::lib::std::convert::Infall
 /// This can happen with some network protocol or large file parsers, where the
 /// input buffer can be full and need to be resized or refilled.
 /// - [`Err::Incomplete`] will report how much more data is needed.
-/// - [`nom::combinator::complete`][crate::combinator::complete] transform [`Err::Incomplete`] to
+/// - [`Parser::complete`][crate::Parser::complete] transform [`Err::Incomplete`] to
 ///   [`Err::Error`]
 ///
 /// See also [`InputIsStreaming`] to tell whether the input supports complete or streaming parsing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! ```rust
 //! use nom::prelude::*;
 //! use nom::bytes::{tag, take_while_m_n};
-//! use nom::combinator::map_res;
 //! use nom::sequence::tuple;
 //!
 //! #[derive(Debug,PartialEq)]
@@ -29,10 +28,7 @@
 //! }
 //!
 //! fn hex_primary(input: &str) -> IResult<&str, u8> {
-//!   map_res(
-//!     take_while_m_n(2, 2, is_hex_digit),
-//!     from_hex
-//!   )(input)
+//!   take_while_m_n(2, 2, is_hex_digit).map_res(from_hex).parse(input)
 //! }
 //!
 //! fn hex_color(input: &str) -> IResult<&str, Color> {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -3,7 +3,6 @@
 #[cfg(test)]
 mod tests;
 
-use crate::combinator::complete;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{InputIsStreaming, InputIter, InputLength, InputTake, IntoOutput, ToUsize};
@@ -967,7 +966,7 @@ where
   move |i: I| {
     let (i, data) = length_data(f.as_mut_parser()).parse(i)?;
     let data = I::from_output(data);
-    let (_, o) = complete(g.as_mut_parser()).parse(data)?;
+    let (_, o) = g.as_mut_parser().complete().parse(data)?;
     Ok((i, o))
   }
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -1,5 +1,6 @@
 use super::{length_data, length_value, many0_count, many1_count};
 use crate::input::Streaming;
+use crate::Parser;
 use crate::{
   bytes::tag,
   character::digit1 as digit,
@@ -363,9 +364,10 @@ impl<I> ParseError<I> for NilError {
 #[cfg(feature = "alloc")]
 fn length_count_test() {
   fn number(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
-    use crate::combinator::map_res;
-
-    map_res(map_res(digit, str::from_utf8), FromStr::from_str)(i)
+    digit
+      .map_res(str::from_utf8)
+      .map_res(FromStr::from_str)
+      .parse(i)
   }
 
   fn cnt(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
@@ -403,9 +405,10 @@ fn length_count_test() {
 #[test]
 fn length_data_test() {
   fn number(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u32> {
-    use crate::combinator::map_res;
-
-    map_res(map_res(digit, str::from_utf8), FromStr::from_str)(i)
+    digit
+      .map_res(str::from_utf8)
+      .map_res(FromStr::from_str)
+      .parse(i)
   }
 
   fn take(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -177,7 +177,7 @@ pub enum Err<E> {
   /// This must only be set when the `Input` is [`InputIsStreaming<true>`], like with
   /// [`Streaming`][crate::input::Streaming]
   ///
-  /// Convert this into an `Error` with [`nom::combinator::complete`][crate::combinator::complete]
+  /// Convert this into an `Error` with [`Parser::complete`][Parser::complete]
   Incomplete(Needed),
   /// The parser had an error (recoverable)
   Error(E),
@@ -329,21 +329,20 @@ pub trait Parser<I, O, E> {
   ///
   /// Because parsers are `FnMut`, they can be called multiple times.  This prevents moving `f`
   /// into [`length_data`][crate::multi::length_data] and `g` into
-  /// [`complete`][crate::combinator::complete]:
+  /// [`complete`][Parser::complete]:
   /// ```rust,compile_fail
   /// # use nom::prelude::*;
   /// # use nom::IResult;
   /// # use nom::Parser;
   /// # use nom::error::ParseError;
   /// # use nom::multi::length_data;
-  /// # use nom::combinator::complete;
   /// pub fn length_value<'i, O, E: ParseError<&'i [u8]>>(
   ///     mut f: impl Parser<&'i [u8], usize, E>,
   ///     mut g: impl Parser<&'i [u8], O, E>
   /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
   ///   move |i: &'i [u8]| {
   ///     let (i, data) = length_data(f).parse(i)?;
-  ///     let (_, o) = complete(g).parse(data)?;
+  ///     let (_, o) = g.complete().parse(data)?;
   ///     Ok((i, o))
   ///   }
   /// }
@@ -356,14 +355,13 @@ pub trait Parser<I, O, E> {
   /// # use nom::Parser;
   /// # use nom::error::ParseError;
   /// # use nom::multi::length_data;
-  /// # use nom::combinator::complete;
   /// pub fn length_value<'i, O, E: ParseError<&'i [u8]>>(
   ///     mut f: impl Parser<&'i [u8], usize, E>,
   ///     mut g: impl Parser<&'i [u8], O, E>
   /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
   ///   move |i: &'i [u8]| {
   ///     let (i, data) = length_data(f.as_mut_parser()).parse(i)?;
-  ///     let (_, o) = complete(g.as_mut_parser()).parse(data)?;
+  ///     let (_, o) = g.as_mut_parser().complete().parse(data)?;
   ///     Ok((i, o))
   ///   }
   /// }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -428,6 +428,35 @@ pub trait Parser<I, O, E> {
     MapRes::new(self, g)
   }
 
+  /// Applies a function returning an `Option` over the result of a parser.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, Parser};
+  /// use nom::character::digit1;
+  /// # fn main() {
+  ///
+  /// let mut parse = digit1.map_opt(|s: &str| s.parse::<u8>().ok());
+  ///
+  /// // the parser will convert the result of digit1 to a number
+  /// assert_eq!(parse.parse("123"), Ok(("", 123)));
+  ///
+  /// // this will fail if digit1 fails
+  /// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  ///
+  /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
+  /// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
+  /// # }
+  /// ```
+  fn map_opt<G, O2>(self, g: G) -> MapOpt<Self, G, O>
+  where
+    Self: core::marker::Sized,
+    G: FnMut(O) -> Option<O2>,
+  {
+    MapOpt::new(self, g)
+  }
+
   /// Creates a second parser from the output of the first one, then apply over the rest of the input
   ///
   /// # Example

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -507,6 +507,28 @@ pub trait Parser<I, O, E> {
     AndThen::new(self, g)
   }
 
+  /// Transforms [`Incomplete`][crate::Err::Incomplete] into [`Error`][crate::Err::Error]
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, input::Streaming, Parser};
+  /// # use nom::bytes::take;
+  /// # fn main() {
+  ///
+  /// let mut parser = take(5u8).complete();
+  ///
+  /// assert_eq!(parser.parse(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
+  /// assert_eq!(parser.parse(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
+  /// # }
+  /// ```
+  fn complete(self) -> Complete<Self>
+  where
+    Self: core::marker::Sized,
+  {
+    Complete::new(self)
+  }
+
   /// Applies a second parser after the first one, return their results as a tuple
   ///
   /// **WARNING:** Deprecated, replaced with [`nom::sequence::tuple`][crate::sequence::tuple]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -395,6 +395,29 @@ pub trait Parser<I, O, E> {
     Value::new(self, val)
   }
 
+  /// If the child parser was successful, return the consumed input as produced value.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, Parser};
+  /// use nom::character::{char, alpha1};
+  /// use nom::sequence::separated_pair;
+  /// # fn main() {
+  ///
+  /// let mut parser = separated_pair(alpha1, char(','), alpha1).recognize();
+  ///
+  /// assert_eq!(parser.parse("abcd,efgh"), Ok(("", "abcd,efgh")));
+  /// assert_eq!(parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
+  /// # }
+  /// ```
+  fn recognize(self) -> Recognize<Self, O>
+  where
+    Self: core::marker::Sized,
+  {
+    Recognize::new(self)
+  }
+
   /// Maps a function over the result of a parser
   ///
   /// # Example

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -372,6 +372,28 @@ pub trait Parser<I, O, E> {
   {
     MutParser::new(self)
   }
+  /// Returns the provided value if the child parser succeeds.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, Parser};
+  /// use nom::character::alpha1;
+  /// # fn main() {
+  ///
+  /// let mut parser = alpha1.value(1234);
+  ///
+  /// assert_eq!(parser.parse("abcd"), Ok(("", 1234)));
+  /// assert_eq!(parser.parse("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// # }
+  /// ```
+  fn value<O2>(self, val: O2) -> Value<Self, O, O2>
+  where
+    Self: core::marker::Sized,
+    O2: Clone,
+  {
+    Value::new(self, val)
+  }
 
   /// Maps a function over the result of a parser
   ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@
 
 use self::Needed::*;
 use crate::combinator::*;
-use crate::error::{self, ErrorKind};
+use crate::error::{self, Context, ErrorKind};
 use crate::input::InputIsStreaming;
 use crate::lib::std::fmt;
 use core::num::NonZeroUsize;
@@ -622,6 +622,17 @@ pub trait Parser<I, O, E> {
     G: Fn(&O2) -> bool,
   {
     Verify::new(self, second)
+  }
+
+  /// If parsing fails, add context to the error
+  ///
+  /// This is used mainly to add user friendly information
+  /// to errors when backtracking through a parse tree.
+  fn context(self, context: &'static str) -> Context<Self, O>
+  where
+    Self: core::marker::Sized,
+  {
+    Context::new(self, context)
   }
 
   /// Transforms [`Incomplete`][crate::Err::Incomplete] into [`Error`][crate::Err::Error]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -418,6 +418,51 @@ pub trait Parser<I, O, E> {
     Recognize::new(self)
   }
 
+  /// if the child parser was successful, return the consumed input with the output
+  /// as a tuple. Functions similarly to [recognize](fn.recognize.html) except it
+  /// returns the parser output as well.
+  ///
+  /// This can be useful especially in cases where the output is not the same type
+  /// as the input, or the input is a user defined type.
+  ///
+  /// Returned tuple is of the format `(produced output, consumed input)`.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::prelude::*;
+  /// # use nom::{Err,error::ErrorKind, IResult};
+  /// use nom::character::{char, alpha1};
+  /// use nom::bytes::tag;
+  /// use nom::sequence::separated_pair;
+  ///
+  /// fn inner_parser(input: &str) -> IResult<&str, bool> {
+  ///     tag("1234").value(true).parse(input)
+  /// }
+  ///
+  /// # fn main() {
+  ///
+  /// let mut consumed_parser = separated_pair(alpha1, char(','), alpha1).value(true).with_recognized();
+  ///
+  /// assert_eq!(consumed_parser.parse("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
+  /// assert_eq!(consumed_parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
+  ///
+  /// // the second output (representing the consumed input)
+  /// // should be the same as that of the `recognize` parser.
+  /// let mut recognize_parser = inner_parser.recognize();
+  /// let mut consumed_parser = inner_parser.with_recognized().map(|(output, consumed)| consumed);
+  ///
+  /// assert_eq!(recognize_parser.parse("1234"), consumed_parser.parse("1234"));
+  /// assert_eq!(recognize_parser.parse("abcd"), consumed_parser.parse("abcd"));
+  /// # }
+  /// ```
+  fn with_recognized(self) -> WithRecognized<Self, O>
+  where
+    Self: core::marker::Sized,
+  {
+    WithRecognized::new(self)
+  }
+
   /// Maps a function over the result of a parser
   ///
   /// # Example

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -507,6 +507,33 @@ pub trait Parser<I, O, E> {
     AndThen::new(self, g)
   }
 
+  /// Returns the result of the child parser if it satisfies a verification function.
+  ///
+  /// The verification function takes as argument a reference to the output of the
+  /// parser.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, Parser};
+  /// # use nom::character::alpha1;
+  /// # fn main() {
+  ///
+  /// let mut parser = alpha1.verify(|s: &str| s.len() == 4);
+  ///
+  /// assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
+  /// assert_eq!(parser.parse("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
+  /// assert_eq!(parser.parse("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// # }
+  /// ```
+  fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
+  where
+    Self: core::marker::Sized,
+    G: Fn(&O2) -> bool,
+  {
+    Verify::new(self, second)
+  }
+
   /// Transforms [`Incomplete`][crate::Err::Incomplete] into [`Error`][crate::Err::Error]
   ///
   /// # Example

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -399,6 +399,35 @@ pub trait Parser<I, O, E> {
     Map::new(self, g)
   }
 
+  /// Applies a function returning a `Result` over the result of a parser.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::{Err,error::ErrorKind, IResult, Parser};
+  /// use nom::character::digit1;
+  /// # fn main() {
+  ///
+  /// let mut parse = digit1.map_res(|s: &str| s.parse::<u8>());
+  ///
+  /// // the parser will convert the result of digit1 to a number
+  /// assert_eq!(parse.parse("123"), Ok(("", 123)));
+  ///
+  /// // this will fail if digit1 fails
+  /// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  ///
+  /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
+  /// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
+  /// # }
+  /// ```
+  fn map_res<G, O2, E2>(self, g: G) -> MapRes<Self, G, O>
+  where
+    Self: core::marker::Sized,
+    G: FnMut(O) -> Result<O2, E2>,
+  {
+    MapRes::new(self, g)
+  }
+
   /// Creates a second parser from the output of the first one, then apply over the rest of the input
   ///
   /// # Example

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test {
   use crate::input::Streaming;
+  use crate::prelude::*;
   #[cfg(feature = "alloc")]
-  use crate::{branch::alt, bytes::tag_no_case, combinator::recognize, multi::many1};
+  use crate::{branch::alt, bytes::tag_no_case, multi::many1};
   use crate::{
     bytes::{is_a, is_not, tag, take, take_till, take_until},
     error::{self, ErrorKind},
@@ -511,7 +512,7 @@ mod test {
     let b = "ababcd";
 
     fn f(i: &str) -> IResult<&str, &str> {
-      recognize(many1(alt((tag("a"), tag("b")))))(i)
+      many1(alt((tag("a"), tag("b")))).recognize().parse(i)
     }
 
     assert_eq!(f(&a[..]), Ok((&a[6..], &a[..])));

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -1,9 +1,9 @@
+use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::tag,
   character::char,
   character::{digit1 as digit, space0 as space},
-  combinator::map_res,
   multi::fold_many0,
   sequence::{delimited, pair},
   IResult,
@@ -24,7 +24,7 @@ fn parens(i: &str) -> IResult<&str, i64> {
 // we fallback to the parens parser defined above
 fn factor(i: &str) -> IResult<&str, i64> {
   alt((
-    map_res(delimited(space, digit, space), FromStr::from_str),
+    delimited(space, digit, space).map_res(FromStr::from_str),
     parens,
   ))(i)
 }

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -8,7 +8,6 @@ use nom::{
   branch::alt,
   bytes::tag,
   character::{digit1 as digit, multispace0 as multispace},
-  combinator::map_res,
   multi::many0,
   sequence::{delimited, preceded},
   IResult,
@@ -69,7 +68,9 @@ fn parens(i: &str) -> IResult<&str, Expr> {
 
 fn factor(i: &str) -> IResult<&str, Expr> {
   alt((
-    map_res(delimited(multispace, digit, multispace), FromStr::from_str).map(Expr::Value),
+    delimited(multispace, digit, multispace)
+      .map_res(FromStr::from_str)
+      .map(Expr::Value),
     parens,
   ))(i)
 }

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -1,5 +1,5 @@
 use nom::bytes::{tag, take_while_m_n};
-use nom::combinator::map_res;
+use nom::prelude::*;
 use nom::sequence::tuple;
 use nom::IResult;
 
@@ -19,7 +19,9 @@ fn is_hex_digit(c: char) -> bool {
 }
 
 fn hex_primary(input: &str) -> IResult<&str, u8> {
-  map_res(take_while_m_n(2, 2, is_hex_digit), from_hex)(input)
+  take_while_m_n(2, 2, is_hex_digit)
+    .map_res(from_hex)
+    .parse(input)
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -2,11 +2,11 @@
 
 use nom::bytes::tag;
 use nom::character::digit1 as digit;
-use nom::combinator::verify;
 use nom::error::{ErrorKind, ParseError};
 use nom::input::Streaming;
 #[cfg(feature = "alloc")]
 use nom::multi::count;
+use nom::prelude::*;
 use nom::sequence::terminated;
 use nom::IResult;
 
@@ -40,7 +40,7 @@ fn test2(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> 
 }
 
 fn test3(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> {
-  verify(test1, |s: &str| s.starts_with("abcd"))(input)
+  test1.verify(|s: &str| s.starts_with("abcd")).parse(input)
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::tag;
 use nom::character::digit1 as digit;
-use nom::combinator::{opt, recognize};
+use nom::combinator::opt;
 use nom::prelude::*;
 use nom::sequence::{delimited, pair};
 use nom::IResult;
@@ -10,10 +10,11 @@ use std::str;
 use std::str::FromStr;
 
 fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
-  let float_bytes = recognize(alt((
+  let float_bytes = alt((
     delimited(digit, tag("."), opt(digit)),
     delimited(opt(digit), tag("."), digit),
-  )));
+  ))
+  .recognize();
   let float_str = float_bytes.map_res(str::from_utf8);
   float_str.map_res(FromStr::from_str).parse(i)
 }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::tag;
 use nom::character::digit1 as digit;
-use nom::combinator::{map_res, opt, recognize};
+use nom::combinator::{opt, recognize};
 use nom::prelude::*;
 use nom::sequence::{delimited, pair};
 use nom::IResult;
@@ -14,8 +14,8 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
     delimited(digit, tag("."), opt(digit)),
     delimited(opt(digit), tag("."), digit),
   )));
-  let float_str = map_res(float_bytes, str::from_utf8);
-  map_res(float_str, FromStr::from_str)(i)
+  let float_str = float_bytes.map_res(str::from_utf8);
+  float_str.map_res(FromStr::from_str).parse(i)
 }
 
 fn float(i: &[u8]) -> IResult<&[u8], f32> {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
 
 use nom::input::Streaming;
+use nom::prelude::*;
 use nom::{error::ErrorKind, Err, IResult, Needed};
 
 #[allow(dead_code)]
@@ -186,8 +187,8 @@ fn issue_942() {
   pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     i: &'a str,
   ) -> IResult<&'a str, usize, E> {
-    use nom::{character::char, error::context, multi::many0_count};
-    many0_count(context("char_a", char('a')))(i)
+    use nom::{character::char, multi::many0_count};
+    many0_count(char('a').context("char_a"))(i)
   }
   assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -26,7 +26,7 @@ mod parse_int {
   use nom::prelude::*;
   use nom::{
     character::{digit1 as digit, space1 as space},
-    combinator::{complete, opt},
+    combinator::opt,
     multi::many0,
     IResult,
   };
@@ -38,8 +38,9 @@ mod parse_int {
 
   fn spaces_or_int(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, i32> {
     println!("{}", input.to_hex(8));
-    let (i, _) = opt(complete(space))(input)?;
-    let (i, res) = complete(digit)
+    let (i, _) = opt(space.complete())(input)?;
+    let (i, res) = digit
+      .complete()
       .map(|x| {
         println!("x: {:?}", x);
         let result = str::from_utf8(x).unwrap();
@@ -133,8 +134,8 @@ fn issue_717(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
 
 mod issue_647 {
   use nom::bytes::tag;
-  use nom::combinator::complete;
   use nom::multi::separated_list0;
+  use nom::prelude::*;
   use nom::{error::Error, number::be_f64, Err, IResult};
   pub type Input<'a> = nom::input::Streaming<&'a [u8]>;
 
@@ -148,7 +149,7 @@ mod issue_647 {
     input: Input<'a>,
     _cs: &'b f64,
   ) -> Result<(Input<'a>, Vec<f64>), Err<Error<Input<'a>>>> {
-    separated_list0(complete(tag(",")), complete(be_f64))(input)
+    separated_list0(tag(",").complete(), be_f64.complete())(input)
   }
 
   fn data(input: Input<'_>) -> IResult<Input<'_>, Data> {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -4,7 +4,6 @@ use nom::{
   branch::alt,
   bytes::{tag, take},
   character::{anychar, char, f64, multispace0, none_of},
-  combinator::value,
   error::ParseError,
   multi::{fold_many0, separated_list0},
   sequence::{delimited, preceded, separated_pair},
@@ -24,7 +23,7 @@ pub enum JsonValue {
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
-  alt((value(false, tag("false")), value(true, tag("true"))))(input)
+  alt((tag("false").value(false), tag("true").value(true)))(input)
 }
 
 fn u16_hex(input: &str) -> IResult<&str, u16> {
@@ -117,7 +116,7 @@ fn json_value(input: &str) -> IResult<&str, JsonValue> {
   use JsonValue::*;
 
   alt((
-    value(Null, tag("null")),
+    tag("null").value(Null),
     boolean.map(Bool),
     string.map(Str),
     f64.map(Num),

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -4,7 +4,7 @@ use nom::{
   branch::alt,
   bytes::{tag, take},
   character::{anychar, char, f64, multispace0, none_of},
-  combinator::{map_opt, map_res, value, verify},
+  combinator::{map_opt, value, verify},
   error::ParseError,
   multi::{fold_many0, separated_list0},
   sequence::{delimited, preceded, separated_pair},
@@ -28,7 +28,9 @@ fn boolean(input: &str) -> IResult<&str, bool> {
 }
 
 fn u16_hex(input: &str) -> IResult<&str, u16> {
-  map_res(take(4usize), |s| u16::from_str_radix(s, 16))(input)
+  take(4usize)
+    .map_res(|s| u16::from_str_radix(s, 16))
+    .parse(input)
 }
 
 fn unicode_escape(input: &str) -> IResult<&str, char> {
@@ -56,7 +58,7 @@ fn character(input: &str) -> IResult<&str, char> {
   let (input, c) = none_of("\"")(input)?;
   if c == '\\' {
     alt((
-      map_res(anychar, |c| {
+      anychar.map_res(|c| {
         Ok(match c {
           '"' | '\\' | '/' => c,
           'b' => '\x08',

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -5,7 +5,6 @@ use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::{tag, take},
-  combinator::map_res,
   error::ErrorKind,
   multi::many0,
   number::{be_f32, be_u16, be_u32, be_u64},
@@ -246,7 +245,7 @@ struct MP4BoxHeader {
 }
 
 fn brand_name(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &str> {
-  map_res(take(4_usize), str::from_utf8)(input)
+  take(4_usize).map_res(str::from_utf8).parse(input)
 }
 
 fn filetype_parser(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, FileType<'_>> {

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -5,7 +5,6 @@ use std::str;
 
 use nom::bytes::is_not;
 use nom::character::char;
-use nom::combinator::map_res;
 use nom::multi::fold_many0;
 use nom::prelude::*;
 use nom::sequence::delimited;
@@ -13,7 +12,8 @@ use nom::IResult;
 
 fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
   move |input| {
-    map_res(is_not(" \t\r\n"), str::from_utf8)
+    is_not(" \t\r\n")
+      .map_res(str::from_utf8)
       .map(ToString::to_string)
       .parse(input)
   }


### PR DESCRIPTION
This is a followup to #37 and is working towards Geal/nom#1408

The criteria for moving parsers was if they were common enough and did not affect the grammar.  This way, the code structure can help highlight the grammar.  This means I left out `cut`.  While it mutates the error, like `complerte`, it does so in a way that affects parsing and it should be elevated (I think).  I'm still a little mixed on that one.

Highlights
- `consumed` -> `Parser::with_recognized`
  - The problem is `recognize` and `consumed` parallel each other
    but its not obvious by the name.   `combine` calls it
    `recognize_with_value`.  `nom-supreme` takes the approach of
    `Parser::with_recognized`.  I feel like that makes the intent clear.
    The problem comes in that `with_recognized` implies an order
    (`u32.with_recognized()`), so I needed to swap the order of the tuple
    elements compared to `consumed`, `combine`s `recognize_with_value`, and
    `nom-supreme`s `with_recognized`.
- `dbg_dmp` -> `Parser::dbg_err`
  - The name changed because we are only printing errors, we might want to
    print something else in the future.  See that commit for more details
  - Support for any input that supports `AsBytes`, instead of just `&[u8]`
  - Allows any displayable context
  - Print to stderr, instead of stdout