### PR TITLE
fix(parser): Rename as_mut_parser to by_ref 

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -202,19 +202,19 @@ where
   Ok((input, len))
 }
 
-/// Implementation of [`Parser::as_mut_parser`][Parser::as_mut_parser]
+/// Implementation of [`Parser::by_ref`][Parser::by_ref]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct MutParser<'p, P> {
+pub struct ByRef<'p, P> {
   p: &'p mut P,
 }
 
-impl<'p, P> MutParser<'p, P> {
+impl<'p, P> ByRef<'p, P> {
   pub(crate) fn new(p: &'p mut P) -> Self {
     Self { p }
   }
 }
 
-impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for MutParser<'p, P> {
+impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
   fn parse(&mut self, i: I) -> IResult<I, O, E> {
     self.p.parse(i)
   }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -113,6 +113,7 @@
 //!
 //! - [`success`][success]: Returns a value without consuming any input, always succeeds
 //! - [`fail`][fail]: Inversion of `success`. Always fails.
+//! - [`Parser::by_ref`]: Allow moving `&mut impl Parser` into other parsers
 //!
 //! ## Character test functions
 //!

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -964,9 +964,9 @@ where
   E: ParseError<I>,
 {
   move |i: I| {
-    let (i, data) = length_data(f.as_mut_parser()).parse(i)?;
+    let (i, data) = length_data(f.by_ref()).parse(i)?;
     let data = I::from_output(data);
-    let (_, o) = g.as_mut_parser().complete().parse(data)?;
+    let (_, o) = g.by_ref().complete().parse(data)?;
     Ok((i, o))
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -348,7 +348,7 @@ pub trait Parser<I, O, E> {
   /// }
   /// ```
   ///
-  /// By adding `as_mut_parser`, we can make this work:
+  /// By adding `by_ref`, we can make this work:
   /// ```rust
   /// # use nom::prelude::*;
   /// # use nom::IResult;
@@ -360,17 +360,17 @@ pub trait Parser<I, O, E> {
   ///     mut g: impl Parser<&'i [u8], O, E>
   /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
   ///   move |i: &'i [u8]| {
-  ///     let (i, data) = length_data(f.as_mut_parser()).parse(i)?;
-  ///     let (_, o) = g.as_mut_parser().complete().parse(data)?;
+  ///     let (i, data) = length_data(f.by_ref()).parse(i)?;
+  ///     let (_, o) = g.by_ref().complete().parse(data)?;
   ///     Ok((i, o))
   ///   }
   /// }
   /// ```
-  fn as_mut_parser(&mut self) -> MutParser<Self>
+  fn by_ref(&mut self) -> ByRef<Self>
   where
     Self: core::marker::Sized,
   {
-    MutParser::new(self)
+    ByRef::new(self)
   }
   /// Returns the provided value if the child parser succeeds.
   ///


### PR DESCRIPTION
I already didn't like the name in https://github.com/epage/nom-experimental/pull/34 but I saw both `nom-supreme` and
`combine` us the `by_ref` name, so figured familiar is better.