### PR TITLE
feat(parser): impl Parser for tuples 

### DIFF
--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -11,7 +11,7 @@ use nom::{
   combinator::{cut, opt},
   error::VerboseError,
   multi::many0,
-  sequence::{delimited, preceded, terminated, tuple},
+  sequence::{delimited, preceded, terminated},
   IResult, Parser,
 };
 
@@ -167,11 +167,11 @@ where
 /// that we need to parse an expression and then parse 0 or more expressions, all
 /// wrapped in an S-expression.
 ///
-/// `tuple` is used to sequence parsers together, so we can translate this directly
+/// tuples are used to sequence parsers together, so we can translate this directly
 /// and then map over it to transform the output into an `Expr::Application`
 fn parse_application<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
-  let application_inner = tuple((parse_expr, many0(parse_expr)))
-    .map(|(head, tail)| Expr::Application(Box::new(head), tail));
+  let application_inner =
+    (parse_expr, many0(parse_expr)).map(|(head, tail)| Expr::Application(Box::new(head), tail));
   // finally, we wrap it in an s-expression
   s_exp(application_inner)(i)
 }
@@ -188,7 +188,7 @@ fn parse_if<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
     // variables to our language, we say that if must be terminated by at least
     // one whitespace character
     terminated(tag("if"), multispace1),
-    cut(tuple((parse_expr, parse_expr, opt(parse_expr)))),
+    cut((parse_expr, parse_expr, opt(parse_expr))),
   )
   .map(|(pred, true_branch, maybe_false_branch)| {
     if let Some(false_branch) = maybe_false_branch {

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -86,16 +86,15 @@
 //! use nom::{
 //!   IResult,
 //!   error::ParseError,
-//!   sequence::tuple,
 //!   bytes::complete::{tag, take_until},
 //! };
 //!
 //! pub fn pinline_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E> {
-//!   tuple((
+//!   (
 //!     tag("(*"),
 //!     take_until("*)"),
 //!     tag("*)")
-//!   ))
+//!   )
 //!     .value(()) // Output is thrown away.
 //!     .parse(i)
 //! }
@@ -278,24 +277,24 @@
 //!   branch::alt,
 //!   multi::{many0, many1},
 //!   combinator::opt,
-//!   sequence::{preceded, terminated, tuple},
+//!   sequence::{preceded, terminated},
 //!   character::complete::{char, one_of},
 //! };
 //!
 //! fn float(input: &str) -> IResult<&str, &str> {
 //!   alt((
 //!     // Case one: .42
-//!     tuple((
+//!     (
 //!       char('.'),
 //!       decimal,
-//!       opt(tuple((
+//!       opt((
 //!         one_of("eE"),
 //!         opt(one_of("+-")),
 //!         decimal
-//!       )))
-//!     )).recognize()
+//!       ))
+//!     ).recognize()
 //!     , // Case two: 42e42 and 42.42e42
-//!     tuple((
+//!     (
 //!       decimal,
 //!       opt(preceded(
 //!         char('.'),
@@ -304,13 +303,13 @@
 //!       one_of("eE"),
 //!       opt(one_of("+-")),
 //!       decimal
-//!     )).recognize()
+//!     ).recognize()
 //!     , // Case three: 42. and 42.42
-//!     tuple((
+//!     (
 //!       decimal,
 //!       char('.'),
 //!       opt(decimal)
-//!     )).recognize()
+//!     ).recognize()
 //!   ))(input)
 //! }
 //!

--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -100,11 +100,10 @@
 //! line parser:
 //!
 //! ```rust
-//! # use nom::IResult;
+//! # use nom::prelude::*;
 //! # use nom::bytes::complete::take_while1;
 //! # use nom::bytes::complete::tag;
 //! # use nom::sequence::preceded;
-//! # use nom::sequence::tuple;
 //! # use nom::AsChar;
 //! struct Request<'s> {
 //!     method: &'s [u8],
@@ -128,10 +127,10 @@
 //!   // if both succeed
 //!   let http_version = preceded(http, version);
 //!
-//!   // tuple takes as argument a tuple of parsers and will return
+//!   // tuples takes as argument a tuple of parsers and will return
 //!   // a tuple of their results
 //!   let (input, (method, _, url, _, version, _)) =
-//!     tuple((method, &space, url, &space, http_version, line_ending))(i)?;
+//!     (method, &space, url, &space, http_version, line_ending).parse(i)?;
 //!
 //!   Ok((input, Request { method, url, version }))
 //! }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -20,11 +20,10 @@ use crate::{Err, IResult, Needed, Parser};
 /// ```
 /// use nom::bits::{bits, take};
 /// use nom::error::Error;
-/// use nom::sequence::tuple;
 /// use nom::IResult;
 ///
 /// fn parse(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
-///     bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input)
+///     bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize)))(input)
 /// }
 ///
 /// let input = &[0x12, 0x34, 0xff, 0xff];
@@ -70,15 +69,14 @@ where
 /// use nom::bits::{bits, bytes, take};
 /// use nom::combinator::rest;
 /// use nom::error::Error;
-/// use nom::sequence::tuple;
 /// use nom::IResult;
 ///
 /// fn parse(input: &[u8]) -> IResult<&[u8], (u8, u8, &[u8])> {
-///   bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((
+///   bits::<_, _, Error<(&[u8], usize)>, _, _>((
 ///     take(4usize),
 ///     take(8usize),
 ///     bytes::<_, _, Error<&[u8]>, _, _>(rest)
-///   )))(input)
+///   ))(input)
 /// }
 ///
 /// let input = &[0x12, 0x34, 0xff, 0xff];

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::error::Error;
 use crate::input::Streaming;
-use crate::sequence::tuple;
 
 #[test]
 /// Take the `bits` function and assert that remaining bytes are correctly returned, if the
@@ -11,9 +10,7 @@ fn test_complete_byte_consumption_bits() {
 
   // Take 3 bit slices with sizes [4, 8, 4].
   let result: IResult<&[u8], (u8, u8, u8)> =
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize), take(4usize))))(
-      input,
-    );
+    bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize), take(4usize)))(input);
 
   let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
 
@@ -36,7 +33,7 @@ fn test_partial_byte_consumption_bits() {
 
   // Take bit slices with sizes [4, 8].
   let result: IResult<&[u8], (u8, u8)> =
-    bits::<_, _, Error<(&[u8], usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+    bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize)))(input);
 
   let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
 
@@ -56,7 +53,7 @@ fn test_incomplete_bits() {
 
   // Take bit slices with sizes [4, 8].
   let result: IResult<_, (u8, u8)> =
-    bits::<_, _, Error<(_, usize)>, _, _>(tuple((take(4usize), take(8usize))))(input);
+    bits::<_, _, Error<(_, usize)>, _, _>((take(4usize), take(8usize)))(input);
 
   assert!(result.is_err());
   let error = result.err().unwrap();

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -38,7 +38,7 @@
 //! | [terminated][crate::sequence::terminated] | `terminated(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", "ab"))` ||
 //! | [pair][crate::sequence::pair] | `pair(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", ("ab", "XY")))` ||
 //! | [separated_pair][crate::sequence::separated_pair] | `separated_pair(tag("hello"), char(','), tag("world"))` | `"hello,world!"` | `Ok(("!", ("hello", "world")))` ||
-//! | [tuple][crate::sequence::tuple] | `tuple((tag("ab"), tag("XY"), take(1)))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
+//! | [`(...)` (tuples)][crate::Parser] | `(tag("ab"), tag("XY"), take(1))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
 //!
 //! ## Applying a parser multiple times
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! ```rust
 //! use nom::prelude::*;
 //! use nom::bytes::{tag, take_while_m_n};
-//! use nom::sequence::tuple;
 //!
 //! #[derive(Debug,PartialEq)]
 //! pub struct Color {
@@ -33,7 +32,7 @@
 //!
 //! fn hex_color(input: &str) -> IResult<&str, Color> {
 //!   let (input, _) = tag("#")(input)?;
-//!   let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+//!   let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse(input)?;
 //!
 //!   Ok((input, Color { red, green, blue }))
 //! }
@@ -251,33 +250,33 @@
 //! - **`many0`**: Will apply the parser 0 or more times (if it returns the `O` type, the new parser returns `Vec<O>`)
 //! - **`many1`**: Will apply the parser 1 or more times
 //!
-//! There are more complex (and more useful) parsers like `tuple`, which is
+//! There are more complex (and more useful) parsers like tuples, which is
 //! used to apply a series of parsers then assemble their results.
 //!
-//! Example with `tuple`:
+//! Example with tuples:
 //!
 //! ```rust
 //! # fn main() {
+//! use nom::prelude::*;
 //! use nom::{
 //!     error::ErrorKind, Needed,
 //!     number::be_u16,
 //!     bytes::{tag, take},
-//!     sequence::tuple,
 //!     input::Streaming,
 //! };
 //!
-//! let mut tpl = tuple((be_u16, take(3u8), tag("fg")));
+//! let mut tpl = (be_u16, take(3u8), tag("fg"));
 //!
 //! assert_eq!(
-//!   tpl(Streaming(&b"abcdefgh"[..])),
+//!   tpl.parse(Streaming(&b"abcdefgh"[..])),
 //!   Ok((
 //!     Streaming(&b"h"[..]),
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl(Streaming(&b"abcde"[..])), Err(nom::Err::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse(Streaming(&b"abcde"[..])), Err(nom::Err::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl(Streaming(input)), Err(nom::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse(Streaming(input)), Err(nom::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -7,7 +7,7 @@ use crate::{
   error::{ErrorKind, ParseError},
   lib::std::str::{self, FromStr},
   number::{be_u16, be_u8},
-  sequence::{pair, tuple},
+  sequence::pair,
   {Err, IResult, Needed},
 };
 #[cfg(feature = "alloc")]
@@ -442,7 +442,7 @@ fn length_value_test() {
     length_value(be_u8, be_u16)(i)
   }
   fn length_value_2(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (u8, u8)> {
-    length_value(be_u8, tuple((be_u8, be_u8)))(i)
+    length_value(be_u8, (be_u8, be_u8))(i)
   }
 
   let i1 = [0, 5, 6];

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -189,11 +189,13 @@ where
 /// Helper trait for the tuple combinator.
 ///
 /// This trait is implemented for tuples of parsers of up to 21 elements.
+#[deprecated(since = "8.0.0", note = "Replaced with `Parser`")]
 pub trait Tuple<I, O, E> {
   /// Parses the input and returns a tuple of results of each parser.
   fn parse(&mut self, input: I) -> IResult<I, O, E>;
 }
 
+#[allow(deprecated)]
 impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
   Tuple<Input, (Output,), Error> for (F,)
 {
@@ -218,6 +220,7 @@ macro_rules! tuple_trait(
 
 macro_rules! tuple_trait_impl(
   ($($name:ident $ty: ident),+) => (
+    #[allow(deprecated)]
     impl<
       Input: Clone, $($ty),+ , Error: ParseError<Input>,
       $($name: Parser<Input, $ty, Error>),+
@@ -255,6 +258,7 @@ tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ 
 // Special case: implement `Tuple` for `()`, the unit type.
 // This can come up in macros which accept a variable number of arguments.
 // Literally, `()` is an empty tuple, so it should simply parse nothing.
+#[allow(deprecated)]
 impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
   fn parse(&mut self, input: I) -> IResult<I, (), E> {
     Ok((input, ()))
@@ -263,6 +267,9 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 
 ///Applies a tuple of parsers one by one and returns their results as a tuple.
 ///There is a maximum of 21 parsers
+///
+/// **WARNING:** Deprecated, [`Parser`] is directly implemented for tuples
+///
 /// ```rust
 /// # use nom::{Err, error::ErrorKind};
 /// use nom::sequence::tuple;
@@ -272,6 +279,8 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
 /// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
 /// ```
+#[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
+#[allow(deprecated)]
 pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
   mut l: List,
 ) -> impl FnMut(I) -> IResult<I, O, E> {

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -7,6 +7,7 @@ use crate::{Err, IResult, Needed};
 
 #[test]
 fn single_element_tuples() {
+  #![allow(deprecated)]
   use crate::character::alpha1;
   use crate::{error::ErrorKind, Err};
 
@@ -303,6 +304,7 @@ fn delimited_test() {
 
 #[test]
 fn tuple_test() {
+  #![allow(deprecated)]
   fn tuple_3(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (u16, &[u8], &[u8])> {
     tuple((be_u16, take(3u8), tag("fg")))(i)
   }
@@ -330,6 +332,7 @@ fn tuple_test() {
 
 #[test]
 fn unit_type() {
+  #![allow(deprecated)]
   assert_eq!(
     tuple::<&'static str, (), Error<&'static str>, ()>(())("abxsbsh"),
     Ok(("abxsbsh", ()))

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -1,7 +1,5 @@
 use nom::bytes::{tag, take_while_m_n};
 use nom::prelude::*;
-use nom::sequence::tuple;
-use nom::IResult;
 
 #[derive(Debug, PartialEq)]
 pub struct Color {
@@ -26,7 +24,7 @@ fn hex_primary(input: &str) -> IResult<&str, u8> {
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
   let (input, _) = tag("#")(input)?;
-  let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+  let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse(input)?;
 
   Ok((input, Color { red, green, blue }))
 }

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -4,8 +4,7 @@ use nom::{
   character::{alphanumeric1 as alphanumeric, char, multispace0 as multispace, space0 as space},
   combinator::opt,
   multi::many0,
-  sequence::{delimited, pair, separated_pair, terminated, tuple},
-  IResult,
+  sequence::{delimited, pair, separated_pair, terminated},
 };
 
 use std::collections::HashMap;
@@ -19,7 +18,7 @@ fn category(i: &[u8]) -> IResult<&[u8], &str> {
 
 fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
   let (i, key) = alphanumeric.map_res(str::from_utf8).parse(i)?;
-  let (i, _) = tuple((opt(space), char('='), opt(space)))(i)?;
+  let (i, _) = (opt(space), char('='), opt(space)).parse(i)?;
   let (i, val) = take_while(|c| c != b'\n' && c != b';')
     .map_res(str::from_utf8)
     .parse(i)?;

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,10 +1,10 @@
+use nom::prelude::*;
 use nom::{
   bytes::{is_a, tag, take_till, take_while},
   character::{alphanumeric1 as alphanumeric, char, space0 as space},
   combinator::opt,
   multi::many0,
-  sequence::{delimited, pair, terminated, tuple},
-  IResult,
+  sequence::{delimited, pair, terminated},
 };
 
 use std::collections::HashMap;
@@ -30,7 +30,7 @@ fn category(i: &str) -> IResult<&str, &str> {
 
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
-  let (i, _) = tuple((opt(space), tag("="), opt(space)))(i)?;
+  let (i, _) = (opt(space), tag("="), opt(space)).parse(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
   let (i, _) = opt(space)(i)?;
   let (i, _) = opt(pair(tag(";"), not_line_ending))(i)?;

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -226,9 +226,8 @@ fn issue_1027_convert_error_panic_nonempty() {
 fn issue_1231_bits_expect_fn_closure() {
   use nom::bits::{bits, take};
   use nom::error::Error;
-  use nom::sequence::tuple;
   pub fn example(input: &[u8]) -> IResult<&[u8], (u8, u8)> {
-    bits::<_, _, Error<_>, _, _>(tuple((take(1usize), take(1usize))))(input)
+    bits::<_, _, Error<_>, _, _>((take(1usize), take(1usize)))(input)
   }
   assert_eq!(example(&[0xff]), Ok((&b""[..], (1, 1))));
 }

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -7,14 +7,14 @@ use nom::input::Streaming;
 use nom::multi::{length_data, many0};
 #[cfg(feature = "alloc")]
 use nom::number::be_u64;
-use nom::sequence::tuple;
-use nom::{Err, IResult, Needed};
+use nom::prelude::*;
+use nom::{Err, Needed};
 
 // Parser definition
 
 // We request a length that would trigger an overflow if computing consumed + requested
 fn parser02(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
-  tuple((take(1_usize), take(18446744073709551615_usize)))(i)
+  (take(1_usize), take(18446744073709551615_usize)).parse(i)
 }
 
 #[test]


### PR DESCRIPTION
More convenient syntax than `tuple((...))`

This was forked from Geal/nom#1425
- I deprecated `tuple()` rather than bothering to re-implement it in terms of `()`
- I didn't see a reason to add a `parse` combinator within this PR

Fixes Geal/nom#1417