### PR TITLE
fix(bytes): Generalize byte/char APIs

### DIFF
--- a/benchmarks/benches/arithmetic.rs
+++ b/benchmarks/benches/arithmetic.rs
@@ -7,7 +7,8 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 use criterion::Criterion;
 use nom::{
   branch::alt,
-  character::complete::{char, digit1, one_of, space0},
+  bytes::one_of,
+  character::complete::{char, digit1, space0},
   combinator::map_res,
   multi::fold_many0,
   sequence::{delimited, pair},

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -3,8 +3,9 @@
 use nom::prelude::*;
 use nom::{
   branch::alt,
+  bytes::one_of,
   bytes::{escaped, tag, take_while},
-  character::{alphanumeric1 as alphanumeric, char, f64, one_of},
+  character::{alphanumeric1 as alphanumeric, char, f64},
   combinator::{cut, opt},
   error::{convert_error, ContextError, ErrorKind, ParseError, VerboseError},
   multi::separated_list0,

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -3,8 +3,9 @@
 use nom::prelude::*;
 use nom::{
   branch::alt,
+  bytes::one_of,
   bytes::{escaped, tag, take_while},
-  character::{alphanumeric1 as alphanumeric, char, f64, one_of},
+  character::{alphanumeric1 as alphanumeric, char, f64},
   combinator::cut,
   error::ParseError,
   multi::separated_list0,

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -6,8 +6,9 @@
 
 use nom::{
   branch::alt,
+  bytes::one_of,
   bytes::tag,
-  character::{alpha1, char, digit1, multispace0, multispace1, one_of},
+  character::{alpha1, char, digit1, multispace0, multispace1},
   combinator::{cut, opt},
   error::VerboseError,
   multi::many0,

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -12,7 +12,7 @@
 #![cfg(feature = "alloc")]
 
 use nom::branch::alt;
-use nom::bytes::{is_not, take_while_m_n};
+use nom::bytes::{take_till1, take_while_m_n};
 use nom::character::{char, multispace1};
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
@@ -96,13 +96,13 @@ fn parse_escaped_whitespace<'a, E: ParseError<&'a str>>(
 
 /// Parse a non-empty block of text that doesn't include \ or "
 fn parse_literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
-  // `is_not` parses a string of 0 or more characters that aren't one of the
+  // `take_till1` parses a string of 0 or more characters that aren't one of the
   // given characters.
-  let not_quote_slash = is_not("\"\\");
+  let not_quote_slash = take_till1("\"\\");
 
   // `verify` runs a parser, then runs a verification function on the output of
   // the parser. The verification function accepts out output only if it
-  // returns true. In this case, we want to ensure that the output of is_not
+  // returns true. In this case, we want to ensure that the output of take_till1
   // is non-empty.
   not_quote_slash.verify(|s: &str| !s.is_empty()).parse(input)
 }

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -64,13 +64,13 @@
 //!   IResult,
 //!   error::ParseError,
 //!   sequence::pair,
-//!   bytes::is_not,
+//!   bytes::take_till1,
 //!   character::char,
 //! };
 //!
 //! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E>
 //! {
-//!   pair(char('%'), is_not("\n\r"))
+//!   pair(char('%'), take_till1("\n\r"))
 //!     .value(()) // Output is thrown away.
 //!     .parse(i)
 //! }

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -164,7 +164,8 @@
 //!   branch::alt,
 //!   multi::{many0, many1},
 //!   sequence::{preceded, terminated},
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //!   bytes::tag,
 //! };
 //!
@@ -187,7 +188,8 @@
 //!   branch::alt,
 //!   multi::{many0, many1},
 //!   sequence::{preceded, terminated},
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //!   bytes::tag,
 //! };
 //!
@@ -211,7 +213,8 @@
 //!   branch::alt,
 //!   multi::{many0, many1},
 //!   sequence::{preceded, terminated},
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //!   bytes::tag,
 //! };
 //!
@@ -233,7 +236,8 @@
 //!   branch::alt,
 //!   multi::{many0, many1},
 //!   sequence::{preceded, terminated},
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //!   bytes::tag,
 //! };
 //!
@@ -255,7 +259,8 @@
 //!   IResult,
 //!   multi::{many0, many1},
 //!   sequence::terminated,
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //! };
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
@@ -278,7 +283,8 @@
 //!   multi::{many0, many1},
 //!   combinator::opt,
 //!   sequence::{preceded, terminated},
-//!   character::{char, one_of},
+//!   character::char,
+//!   bytes::one_of,
 //! };
 //!
 //! fn float(input: &str) -> IResult<&str, &str> {

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -89,17 +89,18 @@ pub trait Permutation<I, O, E> {
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, IResult};
 /// use nom::branch::permutation;
-/// use nom::character::{anychar, char};
+/// use nom::bytes::any;
+/// use nom::character::{char};
 ///
 /// fn parser(input: &str) -> IResult<&str, (char, char)> {
-///   permutation((anychar, char('a')))(input)
+///   permutation((any, char('a')))(input)
 /// }
 ///
-/// // anychar parses 'b', then char('a') parses 'a'
+/// // any parses 'b', then char('a') parses 'a'
 /// assert_eq!(parser("ba"), Ok(("", ('b', 'a'))));
 ///
-/// // anychar parses 'a', then char('a') fails on 'b',
-/// // even though char('a') followed by anychar would succeed
+/// // any parses 'a', then char('a') fails on 'b',
+/// // even though char('a') followed by any would succeed
 /// assert_eq!(parser("ab"), Err(Err::Error(Error::new("b", ErrorKind::Char))));
 /// ```
 ///

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -122,6 +122,26 @@ where
   res.into_output()
 }
 
+pub(crate) fn one_of_internal<I, T, E: ParseError<I>>(
+  input: I,
+  list: &T,
+) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  <I as InputIter>::Item: Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  let mut it = input.iter_indices();
+  match it.next() {
+    Some((_, c)) if list.find_token(c) => match it.next() {
+      None => Ok((input.slice(input.input_len()..), c)),
+      Some((idx, _)) => Ok((input.slice(idx..), c)),
+    },
+    Some(_) => Err(Err::Error(E::from_error_kind(input, ErrorKind::OneOf))),
+    None => Err(Err::Error(E::from_error_kind(input, ErrorKind::OneOf))),
+  }
+}
+
 /// Parse till certain characters are met.
 ///
 /// The parser will return the longest slice till one of the characters of the combinator's argument are met.

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -184,8 +184,8 @@ where
 /// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_not`][crate::bytes::is_not]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::is_not`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till1`][crate::bytes::take_till1]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_till1`")]
 pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -233,8 +233,8 @@ where
 /// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_a`][crate::bytes::is_a]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::is_a`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while1`][crate::bytes::take_while1`]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while1`")]
 pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -282,27 +282,28 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while`][crate::bytes::take_while]
 #[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while`")]
-pub fn take_while<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_while<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_while_internal(i, &cond)
+  move |i: Input| take_while_internal(i, &list)
 }
 
-pub(crate) fn take_while_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  i.split_at_position_complete(|c| !cond(c)).into_output()
+  i.split_at_position_complete(|c| !list.find_token(c))
+    .into_output()
 }
 
 /// Returns the longest (at least 1) input slice that matches the predicate.
@@ -328,28 +329,29 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while1`][crate::bytes::take_while1]
 #[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while1`")]
-pub fn take_while1<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_while1<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_while1_internal(i, &cond)
+  move |i: Input| take_while1_internal(i, &list)
 }
 
-pub(crate) fn take_while1_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_position1_complete(|c| !cond(c), e).into_output()
+  i.split_at_position1_complete(|c| !list.find_token(c), e)
+    .into_output()
 }
 
 /// Returns the longest (m <= len <= n) input slice  that matches the predicate.
@@ -378,31 +380,31 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while_m_n`][crate::bytes::take_while_m_n]
 #[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_while_m_n`")]
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(
+pub fn take_while_m_n<T, Input, Error: ParseError<Input>>(
   m: usize,
   n: usize,
-  cond: F,
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   Input: IntoOutput,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  T: FindToken<<Input as InputIter>::Item>,
 {
-  move |i: Input| take_while_m_n_internal(i, m, n, &cond)
+  move |i: Input| take_while_m_n_internal(i, m, n, &list)
 }
 
-pub(crate) fn take_while_m_n_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while_m_n_internal<T, Input, Error: ParseError<Input>>(
   input: Input,
   m: usize,
   n: usize,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   Input: IntoOutput,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  T: FindToken<<Input as InputIter>::Item>,
 {
-  match input.position(|c| !cond(c)) {
+  match input.position(|c| !list.find_token(c)) {
     Some(idx) => {
       if idx >= m {
         if idx <= n {

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -13,6 +13,20 @@ use crate::lib::std::result::Result::*;
 use crate::IntoOutputIResult;
 use crate::{Err, IResult, Parser};
 
+pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: InputIter + InputLength + Slice<RangeFrom<usize>>,
+{
+  let mut it = input.iter_indices();
+  match it.next() {
+    None => Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof))),
+    Some((_, c)) => match it.next() {
+      None => Ok((input.slice(input.input_len()..), c)),
+      Some((idx, _)) => Ok((input.slice(idx..), c)),
+    },
+  }
+}
+
 /// Recognizes a pattern
 ///
 /// The input data will be compared to the tag combinator's argument and will return the part of

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -475,27 +475,28 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till`][crate::bytes::take_till]
 #[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_till`")]
-pub fn take_till<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_till<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_till_internal(i, &cond)
+  move |i: Input| take_till_internal(i, &list)
 }
 
-pub(crate) fn take_till_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  i.split_at_position_complete(|c| cond(c)).into_output()
+  i.split_at_position_complete(|c| list.find_token(c))
+    .into_output()
 }
 
 /// Returns the longest (at least 1) input slice till a predicate is met.
@@ -522,28 +523,29 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till1`][crate::bytes::take_till1]
 #[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::take_till1`")]
-pub fn take_till1<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_till1<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_till1_internal(i, &cond)
+  move |i: Input| take_till1_internal(i, &list)
 }
 
-pub(crate) fn take_till1_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_position1_complete(|c| cond(c), e).into_output()
+  i.split_at_position1_complete(|c| list.find_token(c), e)
+    .into_output()
 }
 
 /// Returns an input slice containing the first N input elements (Input[..N]).

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -142,6 +142,26 @@ where
   }
 }
 
+pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
+  input: I,
+  list: &T,
+) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  <I as InputIter>::Item: Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  let mut it = input.iter_indices();
+  match it.next() {
+    Some((_, c)) if !list.find_token(c) => match it.next() {
+      None => Ok((input.slice(input.input_len()..), c)),
+      Some((idx, _)) => Ok((input.slice(idx..), c)),
+    },
+    Some(_) => Err(Err::Error(E::from_error_kind(input, ErrorKind::NoneOf))),
+    None => Err(Err::Error(E::from_error_kind(input, ErrorKind::NoneOf))),
+  }
+}
+
 /// Parse till certain characters are met.
 ///
 /// The parser will return the longest slice till one of the characters of the combinator's argument are met.

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -493,10 +493,7 @@ where
   }
 }
 
-/// Returns the longest input slice (if any) till a predicate is met.
-///
-/// The parser will return the longest slice till the given predicate *(a function that
-/// takes the input and returns a bool)*.
+/// Returns the longest input slice (if any) till a [pattern][FindToken] is met.
 ///
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
@@ -531,27 +528,24 @@ where
 /// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_till<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
-  cond: F,
+pub fn take_till<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
     if STREAMING {
-      streaming::take_till_internal(i, &cond)
+      streaming::take_till_internal(i, &list)
     } else {
-      complete::take_till_internal(i, &cond)
+      complete::take_till_internal(i, &list)
     }
   }
 }
 
-/// Returns the longest (at least 1) input slice till a predicate is met.
-///
-/// The parser will return the longest slice till the given predicate *(a function that
-/// takes the input and returns a bool)*.
+/// Returns the longest (at least 1) input slice till a [pattern][FindToken] is met.
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
@@ -589,19 +583,19 @@ where
 /// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_till1<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
-  cond: F,
+pub fn take_till1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
     if STREAMING {
-      streaming::take_till1_internal(i, &cond)
+      streaming::take_till1_internal(i, &list)
     } else {
-      complete::take_till1_internal(i, &cond)
+      complete::take_till1_internal(i, &list)
     }
   }
 }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -326,10 +326,7 @@ where
   }
 }
 
-/// Returns the longest input slice (if any) that matches the predicate.
-///
-/// The parser will return the longest slice that matches the given predicate *(a function that
-/// takes the input and returns a bool)*.
+/// Returns the longest input slice (if any) that matches the [pattern][FindToken]
 ///
 /// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
@@ -364,29 +361,25 @@ where
 /// assert_eq!(alpha(Streaming(b"")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_while<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
-  cond: F,
+pub fn take_while<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
   Input: InputTakeAtPosition,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
 {
   move |i: Input| {
     if STREAMING {
-      streaming::take_while_internal(i, &cond)
+      streaming::take_while_internal(i, &list)
     } else {
-      complete::take_while_internal(i, &cond)
+      complete::take_while_internal(i, &list)
     }
   }
 }
 
-/// Returns the longest (at least 1) input slice that matches the predicate.
-///
-/// The parser will return the longest slice that matches the given predicate *(a function that
-/// takes the input and returns a bool)*.
+/// Returns the longest (at least 1) input slice that matches the [pattern][FindToken]
 ///
 /// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
@@ -422,27 +415,24 @@ where
 /// assert_eq!(alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
 /// ```
 #[inline(always)]
-pub fn take_while1<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
-  cond: F,
+pub fn take_while1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   move |i: Input| {
     if STREAMING {
-      streaming::take_while1_internal(i, &cond)
+      streaming::take_while1_internal(i, &list)
     } else {
-      complete::take_while1_internal(i, &cond)
+      complete::take_while1_internal(i, &list)
     }
   }
 }
 
-/// Returns the longest (m <= len <= n) input slice  that matches the predicate.
-///
-/// The parser will return the longest slice that matches the given predicate *(a function that
-/// takes the input and returns a bool)*.
+/// Returns the longest (m <= len <= n) input slice that matches the [pattern][FindToken]
 ///
 /// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
@@ -483,22 +473,22 @@ where
 /// assert_eq!(short_alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
 /// ```
 #[inline(always)]
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>, const STREAMING: bool>(
+pub fn take_while_m_n<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   m: usize,
   n: usize,
-  cond: F,
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input:
     InputTake + InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  T: FindToken<<Input as InputIter>::Item>,
 {
   move |i: Input| {
     if STREAMING {
-      streaming::take_while_m_n_internal(i, m, n, &cond)
+      streaming::take_while_m_n_internal(i, m, n, &list)
     } else {
-      complete::take_while_m_n_internal(i, m, n, &cond)
+      complete::take_while_m_n_internal(i, m, n, &list)
     }
   }
 }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -169,20 +169,36 @@ where
 /// # Example
 ///
 /// ```
-/// # use nom::{Err, error::ErrorKind};
+/// # use nom::*;
+/// # use nom::{Err, error::ErrorKind, error::Error};
 /// # use nom::bytes::one_of;
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("abc")("b"), Ok(("", 'b')));
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
+///
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     one_of(|c| c == 'a' || c == 'b')(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::*;
+/// # use nom::{Err, error::ErrorKind, error::Error, Needed};
 /// # use nom::input::Streaming;
 /// # use nom::bytes::one_of;
 /// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
 /// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("bc")), Err(Err::Error((Streaming("bc"), ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+///
+/// fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+///     one_of(|c| c == 'a' || c == 'b')(i)
+/// }
+/// assert_eq!(parser(Streaming("abc")), Ok((Streaming("bc"), 'a')));
+/// assert_eq!(parser(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
+/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -13,6 +13,44 @@ use crate::input::{
 use crate::lib::std::ops::RangeFrom;
 use crate::{IResult, Parser};
 
+/// Matches one token
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+///
+/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
+///
+/// # Example
+///
+/// ```
+/// # use nom::{bytes::any, Err, error::{Error, ErrorKind}, IResult};
+/// fn parser(input: &str) -> IResult<&str, char> {
+///     any(input)
+/// }
+///
+/// assert_eq!(parser("abc"), Ok(("bc",'a')));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```
+///
+/// ```
+/// # use nom::{bytes::any, Err, error::ErrorKind, IResult, Needed};
+/// # use nom::input::Streaming;
+/// assert_eq!(any::<_, (_, ErrorKind), true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
+/// assert_eq!(any::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// ```
+#[inline(always)]
+pub fn any<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
+{
+  if STREAMING {
+    streaming::any(input)
+  } else {
+    complete::any(input)
+  }
+}
+
 /// Recognizes a pattern
 ///
 /// The input data will be compared to the tag combinator's argument and will return the part of

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -302,27 +302,28 @@ where
   since = "8.0.0",
   note = "Replaced with `nom::bytes::take_while` with input wrapped in `nom::input::Streaming`"
 )]
-pub fn take_while<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_while<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_while_internal(i, &cond)
+  move |i: Input| take_while_internal(i, &list)
 }
 
-pub(crate) fn take_while_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  i.split_at_position_streaming(|c| !cond(c)).into_output()
+  i.split_at_position_streaming(|c| !list.find_token(c))
+    .into_output()
 }
 
 /// Returns the longest (at least 1) input slice that matches the predicate.
@@ -355,28 +356,28 @@ where
   since = "8.0.0",
   note = "Replaced with `nom::bytes::take_while1` with input wrapped in `nom::input::Streaming`"
 )]
-pub fn take_while1<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_while1<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_while1_internal(i, &cond)
+  move |i: Input| take_while1_internal(i, &list)
 }
 
-pub(crate) fn take_while1_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_position1_streaming(|c| !cond(c), e)
+  i.split_at_position1_streaming(|c| !list.find_token(c), e)
     .into_output()
 }
 
@@ -411,33 +412,33 @@ where
   since = "8.0.0",
   note = "Replaced with `nom::bytes::take_while_m_n` with input wrapped in `nom::input::Streaming`"
 )]
-pub fn take_while_m_n<F, Input, Error: ParseError<Input>>(
+pub fn take_while_m_n<T, Input, Error: ParseError<Input>>(
   m: usize,
   n: usize,
-  cond: F,
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTake + InputIter + InputLength,
   Input: IntoOutput,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  T: FindToken<<Input as InputIter>::Item>,
 {
-  move |i: Input| take_while_m_n_internal(i, m, n, &cond)
+  move |i: Input| take_while_m_n_internal(i, m, n, &list)
 }
 
-pub(crate) fn take_while_m_n_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_while_m_n_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
   m: usize,
   n: usize,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTake + InputIter + InputLength,
   Input: IntoOutput,
-  F: Fn(<Input as InputIter>::Item) -> bool,
+  T: FindToken<<Input as InputIter>::Item>,
 {
   let input = i;
 
-  match input.position(|c| !cond(c)) {
+  match input.position(|c| !list.find_token(c)) {
     Some(idx) => {
       if idx >= m {
         if idx <= n {

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -148,6 +148,26 @@ where
   }
 }
 
+pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
+  input: I,
+  list: &T,
+) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  <I as InputIter>::Item: Copy,
+  T: FindToken<<I as InputIter>::Item>,
+{
+  let mut it = input.iter_indices();
+  match it.next() {
+    Some((_, c)) if !list.find_token(c) => match it.next() {
+      None => Ok((input.slice(input.input_len()..), c)),
+      Some((idx, _)) => Ok((input.slice(idx..), c)),
+    },
+    Some(_) => Err(Err::Error(E::from_error_kind(input, ErrorKind::NoneOf))),
+    None => Err(Err::Incomplete(Needed::new(1))),
+  }
+}
+
 /// Parse till certain characters are met.
 ///
 /// The parser will return the longest slice till one of the characters of the combinator's argument are met.

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -244,10 +244,10 @@ where
 /// assert_eq!(hex(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_a`][crate::bytes::is_a] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_while1`][crate::bytes::take_while1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
 #[deprecated(
   since = "8.0.0",
-  note = "Replaced with `nom::bytes::is_a` with input wrapped in `nom::input::Streaming`"
+  note = "Replaced with `nom::bytes::take_while1` with input wrapped in `nom::input::Streaming`"
 )]
 pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -514,27 +514,28 @@ where
   since = "8.0.0",
   note = "Replaced with `nom::bytes::take_till` with input wrapped in `nom::input::Streaming`"
 )]
-pub fn take_till<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_till<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_till_internal(i, &cond)
+  move |i: Input| take_till_internal(i, &list)
 }
 
-pub(crate) fn take_till_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  i.split_at_position_streaming(|c| cond(c)).into_output()
+  i.split_at_position_streaming(|c| list.find_token(c))
+    .into_output()
 }
 
 /// Returns the longest (at least 1) input slice till a predicate is met.
@@ -565,28 +566,29 @@ where
   since = "8.0.0",
   note = "Replaced with `nom::bytes::take_till1` with input wrapped in `nom::input::Streaming`"
 )]
-pub fn take_till1<F, Input, Error: ParseError<Input>>(
-  cond: F,
+pub fn take_till1<T, Input, Error: ParseError<Input>>(
+  list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
-  move |i: Input| take_till1_internal(i, &cond)
+  move |i: Input| take_till1_internal(i, &list)
 }
 
-pub(crate) fn take_till1_internal<F, Input, Error: ParseError<Input>>(
+pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
   i: Input,
-  cond: &F,
+  list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
   Input: InputTakeAtPosition,
   Input: IntoOutput,
-  F: Fn(<Input as InputTakeAtPosition>::Item) -> bool,
+  T: FindToken<<Input as InputTakeAtPosition>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_position1_streaming(|c| cond(c), e).into_output()
+  i.split_at_position1_streaming(|c| list.find_token(c), e)
+    .into_output()
 }
 
 /// Returns an input slice containing the first N input elements (Input[..N]).

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -13,6 +13,20 @@ use crate::lib::std::result::Result::*;
 use crate::IntoOutputIResult;
 use crate::{Err, IResult, Needed, Parser};
 
+pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as InputIter>::Item, E>
+where
+  I: InputIter + InputLength + Slice<RangeFrom<usize>>,
+{
+  let mut it = input.iter_indices();
+  match it.next() {
+    None => Err(Err::Incomplete(Needed::new(1))),
+    Some((_, c)) => match it.next() {
+      None => Ok((input.slice(input.input_len()..), c)),
+      Some((idx, _)) => Ok((input.slice(idx..), c)),
+    },
+  }
+}
+
 /// Recognizes a pattern.
 ///
 /// The input data will be compared to the tag combinator's argument and will return the part of

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -190,10 +190,10 @@ where
 /// assert_eq!(not_space(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::bytes::is_not`][crate::bytes::is_not] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::take_till1`][crate::bytes::take_till1] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
 #[deprecated(
   since = "8.0.0",
-  note = "Replaced with `nom::bytes::is_not` with input wrapped in `nom::input::Streaming`"
+  note = "Replaced with `nom::bytes::take_till1` with input wrapped in `nom::input::Streaming`"
 )]
 pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -310,7 +310,7 @@ fn streaming_none_of_test() {
 #[test]
 fn streaming_is_a() {
   fn a_or_b(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    is_a("ab")(i)
+    take_while1("ab")(i)
   }
 
   let a = Streaming(&b"abcd"[..]);
@@ -322,7 +322,7 @@ fn streaming_is_a() {
   let c = Streaming(&b"cdef"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(Err::Error(error_position!(c, ErrorKind::IsA)))
+    Err(Err::Error(error_position!(c, ErrorKind::TakeWhile1)))
   );
 
   let d = Streaming(&b"bacdef"[..]);

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -332,7 +332,7 @@ fn streaming_is_a() {
 #[test]
 fn streaming_is_not() {
   fn a_or_b(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    is_not("ab")(i)
+    take_till1("ab")(i)
   }
 
   let a = Streaming(&b"cdab"[..]);
@@ -344,7 +344,7 @@ fn streaming_is_not() {
   let c = Streaming(&b"abab"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(Err::Error(error_position!(c, ErrorKind::IsNot)))
+    Err(Err::Error(error_position!(c, ErrorKind::TakeTill1)))
   );
 
   let d = Streaming(&b"cdefba"[..]);

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -292,6 +292,22 @@ fn streaming_one_of_test() {
 }
 
 #[test]
+fn streaming_none_of_test() {
+  fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u8> {
+    none_of("ab")(i)
+  }
+
+  let a = &b"abcd"[..];
+  assert_eq!(
+    f(Streaming(a)),
+    Err(Err::Error(error_position!(Streaming(a), ErrorKind::NoneOf)))
+  );
+
+  let b = &b"cde"[..];
+  assert_eq!(f(Streaming(b)), Ok((Streaming(&b"de"[..]), b'c')));
+}
+
+#[test]
 fn streaming_is_a() {
   fn a_or_b(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     is_a("ab")(i)

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -269,6 +269,15 @@ fn complete_escape_transform_str() {
 }
 
 #[test]
+fn streaming_any_str() {
+  use super::any;
+  assert_eq!(
+    any::<_, (Streaming<&str>, ErrorKind), true>(Streaming("Ә")),
+    Ok((Streaming(""), 'Ә'))
+  );
+}
+
+#[test]
 fn streaming_one_of_test() {
   fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, u8> {
     one_of("ab")(i)

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -357,21 +357,14 @@ where
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::anychar`][crate::character::anychar]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::anychar`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::any`][crate::bytes::any]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::any`")]
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
   T: InputIter + InputLength + Slice<RangeFrom<usize>>,
   <T as InputIter>::Item: AsChar,
 {
-  let mut it = input.iter_indices();
-  match it.next() {
-    None => Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof))),
-    Some((_, c)) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c.as_char())),
-      Some((idx, _)) => Ok((input.slice(idx..), c.as_char())),
-    },
-  }
+  crate::bytes::complete::any(input).map(|(i, c)| (i, c.as_char()))
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -116,27 +116,15 @@ where
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::one_of`][crate::character::one_of]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::one_of`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::one_of`][crate::bytes::one_of]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::one_of`")]
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: AsChar + Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  move |i: I| one_of_internal(i, &list)
-}
-
-pub(crate) fn one_of_internal<I, T, Error: ParseError<I>>(i: I, list: &T) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter,
-  <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
-{
-  match (i).iter_elements().next().map(|c| (c, list.find_token(c))) {
-    Some((c, true)) => Ok((i.slice(c.len()..), c.as_char())),
-    _ => Err(Err::Error(Error::from_error_kind(i, ErrorKind::OneOf))),
-  }
+  move |i: I| crate::bytes::complete::one_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }
 
 /// Recognizes a character that is not in the provided characters.

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -140,30 +140,15 @@ where
 /// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::none_of`][crate::character::none_of]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::none_of`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::none_of`][crate::bytes::none_of]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::none_of`")]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter,
+  I: Slice<RangeFrom<usize>> + InputLength + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  move |i: I| none_of_internal(i, &list)
-}
-
-pub(crate) fn none_of_internal<I, T, Error: ParseError<I>>(
-  i: I,
-  list: &T,
-) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter,
-  <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
-{
-  match (i).iter_elements().next().map(|c| (c, !list.find_token(c))) {
-    Some((c, true)) => Ok((i.slice(c.len()..), c.as_char())),
-    _ => Err(Err::Error(Error::from_error_kind(i, ErrorKind::NoneOf))),
-  }
+  move |i: I| crate::bytes::complete::none_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }
 
 /// Recognizes the string "\r\n".

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -73,8 +73,8 @@ where
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::satisfy`][crate::character::satisfy]
-#[deprecated(since = "8.0.0", note = "Replaced with `nom::character::satisfy`")]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::one_of`][crate::bytes::one_of]
+#[deprecated(since = "8.0.0", note = "Replaced with `nom::bytes::one_of`")]
 pub fn satisfy<F, I, Error: ParseError<I>>(cond: F) -> impl Fn(I) -> IResult<I, char, Error>
 where
   I: Slice<RangeFrom<usize>> + InputIter,

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -338,44 +338,6 @@ where
   }
 }
 
-/// Matches one byte as a character. Note that the input type will
-/// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
-///
-/// *Complete version*: Will return an error if there's not enough input data.
-///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
-///
-/// # Example
-///
-/// ```
-/// # use nom::{character::anychar, Err, error::{Error, ErrorKind}, IResult};
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     anychar(input)
-/// }
-///
-/// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
-/// ```
-///
-/// ```
-/// # use nom::{character::anychar, Err, error::ErrorKind, IResult, Needed};
-/// # use nom::input::Streaming;
-/// assert_eq!(anychar::<_, (_, ErrorKind), true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
-/// assert_eq!(anychar::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
-/// ```
-#[inline(always)]
-pub fn anychar<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, char, E>
-where
-  T: InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
-  <T as InputIter>::Item: AsChar,
-{
-  if STREAMING {
-    streaming::anychar(input)
-  } else {
-    complete::anychar(input)
-  }
-}
-
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
 ///
 /// *Complete version*: Will return the whole input if no terminating token is found (a non

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -12,8 +12,8 @@ mod tests;
 use crate::error::ParseError;
 use crate::input::Compare;
 use crate::input::{
-  AsBytes, AsChar, FindToken, InputIsStreaming, InputIter, InputLength, InputTake,
-  InputTakeAtPosition, IntoOutput, Offset, ParseTo, Slice,
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtPosition,
+  IntoOutput, Offset, ParseTo, Slice,
 };
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
 use crate::IResult;
@@ -110,48 +110,6 @@ where
       streaming::satisfy_internal(i, &cond)
     } else {
       complete::satisfy_internal(i, &cond)
-    }
-  }
-}
-
-/// Recognizes a character that is not in the provided characters.
-///
-/// *Complete version*: Will return an error if there's not enough input data.
-///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
-///
-/// # Example
-///
-/// ```
-/// # use nom::{Err, error::ErrorKind};
-/// # use nom::character::none_of;
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
-/// ```
-///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::input::Streaming;
-/// # use nom::character::none_of;
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("ab")(Streaming("a")), Err(Err::Error((Streaming("a"), ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
-/// ```
-#[inline(always)]
-pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
-  list: T,
-) -> impl Fn(I) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
-  <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
-{
-  move |i: I| {
-    if STREAMING {
-      streaming::none_of_internal(i, &list)
-    } else {
-      complete::none_of_internal(i, &list)
     }
   }
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -66,54 +66,6 @@ where
   }
 }
 
-/// Recognizes one character and checks that it satisfies a predicate
-///
-/// *Complete version*: Will return an error if there's not enough input data.
-///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
-///
-/// # Example
-///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::satisfy;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     satisfy(|c| c == 'a' || c == 'b')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
-/// ```
-///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::input::Streaming;
-/// # use nom::character::satisfy;
-/// fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
-///     satisfy(|c| c == 'a' || c == 'b')(i)
-/// }
-/// assert_eq!(parser(Streaming("abc")), Ok((Streaming("bc"), 'a')));
-/// assert_eq!(parser(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::Satisfy))));
-/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
-/// ```
-#[inline(always)]
-pub fn satisfy<F, I, Error: ParseError<I>, const STREAMING: bool>(
-  cond: F,
-) -> impl Fn(I) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
-  <I as InputIter>::Item: AsChar,
-  F: Fn(char) -> bool,
-{
-  move |i: I| {
-    if STREAMING {
-      streaming::satisfy_internal(i, &cond)
-    } else {
-      complete::satisfy_internal(i, &cond)
-    }
-  }
-}
-
 /// Recognizes the string "\r\n".
 ///
 /// *Complete version*: Will return an error if there's not enough input data.

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -114,48 +114,6 @@ where
   }
 }
 
-/// Recognizes one of the provided characters.
-///
-/// *Complete version*: Will return an error if there's not enough input data.
-///
-/// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
-///
-/// # Example
-///
-/// ```
-/// # use nom::{Err, error::ErrorKind};
-/// # use nom::character::one_of;
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
-/// ```
-///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::input::Streaming;
-/// # use nom::character::one_of;
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("bc")), Err(Err::Error((Streaming("bc"), ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
-/// ```
-#[inline(always)]
-pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
-  list: T,
-) -> impl Fn(I) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter + InputIsStreaming<STREAMING>,
-  <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
-{
-  move |i: I| {
-    if STREAMING {
-      streaming::one_of_internal(i, &list)
-    } else {
-      complete::one_of_internal(i, &list)
-    }
-  }
-}
-
 /// Recognizes a character that is not in the provided characters.
 ///
 /// *Complete version*: Will return an error if there's not enough input data.

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -359,24 +359,17 @@ where
 /// assert_eq!(anychar::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::anychar`][crate::character::anychar] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::any`][crate::bytes::any] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
 #[deprecated(
   since = "8.0.0",
-  note = "Replaced with `nom::character::anychar` with input wrapped in `nom::input::Streaming`"
+  note = "Replaced with `nom::bytes::any` with input wrapped in `nom::input::Streaming`"
 )]
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
   T: InputIter + InputLength + Slice<RangeFrom<usize>>,
   <T as InputIter>::Item: AsChar,
 {
-  let mut it = input.iter_indices();
-  match it.next() {
-    None => Err(Err::Incomplete(Needed::new(1))),
-    Some((_, c)) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c.as_char())),
-      Some((idx, _)) => Ok((input.slice(idx..), c.as_char())),
-    },
-  }
+  crate::bytes::streaming::any(input).map(|(i, c)| (i, c.as_char()))
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -150,34 +150,18 @@ where
 /// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::none_of`][crate::character::none_of] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::none_of`][crate::bytes::none_of] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
 #[deprecated(
   since = "8.0.0",
-  note = "Replaced with `nom::character::none_of` with input wrapped in `nom::input::Streaming`"
+  note = "Replaced with `nom::bytes::none_of` with input wrapped in `nom::input::Streaming`"
 )]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter,
+  I: Slice<RangeFrom<usize>> + InputLength + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  move |i: I| none_of_internal(i, &list)
-}
-
-pub(crate) fn none_of_internal<I, T, Error: ParseError<I>>(
-  i: I,
-  list: &T,
-) -> IResult<I, char, Error>
-where
-  I: Slice<RangeFrom<usize>> + InputIter,
-  <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
-{
-  match (i).iter_elements().next().map(|c| (c, !list.find_token(c))) {
-    None => Err(Err::Incomplete(Needed::new(1))),
-    Some((_, false)) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::NoneOf))),
-    Some((c, true)) => Ok((i.slice(c.len()..), c.as_char())),
-  }
+  move |i: I| crate::bytes::streaming::none_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }
 
 /// Recognizes the string "\r\n".

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -76,10 +76,10 @@ where
 /// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
 /// ```
 ///
-/// **WARNING:** Deprecated, replaced with [`nom::character::satisfy`][crate::character::satisfy] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
+/// **WARNING:** Deprecated, replaced with [`nom::bytes::one_of`][crate::bytes::one_of] with input wrapped in [`nom::input::Streaming`][crate::input::Streaming]
 #[deprecated(
   since = "8.0.0",
-  note = "Replaced with `nom::character::satisfy` with input wrapped in `nom::input::Streaming`"
+  note = "Replaced with `nom::bytes::one_of` with input wrapped in `nom::input::Streaming`"
 )]
 pub fn satisfy<F, I, Error: ParseError<I>>(cond: F) -> impl Fn(I) -> IResult<I, char, Error>
 where

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -1055,29 +1055,6 @@ mod streaming {
   }
 
   #[test]
-  fn one_of_test() {
-    fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
-      one_of("ab")(i)
-    }
-
-    let a = &b"abcd"[..];
-    assert_eq!(f(Streaming(a)), Ok((Streaming(&b"bcd"[..]), 'a')));
-
-    let b = &b"cde"[..];
-    assert_eq!(
-      f(Streaming(b)),
-      Err(Err::Error(error_position!(Streaming(b), ErrorKind::OneOf)))
-    );
-
-    fn utf8(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
-      one_of("+\u{FF0B}")(i)
-    }
-
-    assert!(utf8(Streaming("+")).is_ok());
-    assert!(utf8(Streaming("\u{FF0B}")).is_ok());
-  }
-
-  #[test]
   fn none_of_test() {
     fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
       none_of("ab")(i)

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -1055,22 +1055,6 @@ mod streaming {
   }
 
   #[test]
-  fn none_of_test() {
-    fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
-      none_of("ab")(i)
-    }
-
-    let a = &b"abcd"[..];
-    assert_eq!(
-      f(Streaming(a)),
-      Err(Err::Error(error_position!(Streaming(a), ErrorKind::NoneOf)))
-    );
-
-    let b = &b"cde"[..];
-    assert_eq!(f(Streaming(b)), Ok((Streaming(&b"de"[..]), 'c')));
-  }
-
-  #[test]
   fn char_byteslice() {
     fn f(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, char> {
       char('c')(i)

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -521,15 +521,6 @@ mod streaming {
   );
 
   #[test]
-  fn anychar_str() {
-    use super::anychar;
-    assert_eq!(
-      anychar::<_, (Streaming<&str>, ErrorKind), true>(Streaming("Ә")),
-      Ok((Streaming(""), 'Ә'))
-    );
-  }
-
-  #[test]
   fn character() {
     let a: &[u8] = b"abcd";
     let b: &[u8] = b"1234";

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -19,7 +19,7 @@
 //! | [tag_no_case][crate::bytes::tag_no_case] | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
 //! | [take][crate::bytes::take] | `take(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|
 //! | [take_while][crate::bytes::take_while] | `take_while(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided pattern matches. `take_while1` does the same, but must return at least one character|
-//! | [take_till][crate::bytes::take_till] | `take_till(is_alphabetic)` |  `"123abc"` | `Ok(("abc", "123"))` |Returns the longest list of bytes or characters until the provided function returns true. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(\|c\| !f(c))`|
+//! | [take_till][crate::bytes::take_till] | `take_till(is_alphabetic)` |  `"123abc"` | `Ok(("abc", "123"))` |Returns the longest list of bytes or characters until the provided pattern matches. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(\|c\| !f(c))`|
 //! | [take_until][crate::bytes::take_until] | `take_until("world")` |  `"Hello world"` | `Ok(("world", "Hello "))` |Returns the longest list of bytes or characters until the provided tag is found. `take_until1` does the same, but must return at least one character|
 //!
 //! ## Choice combinators

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -18,7 +18,7 @@
 //! | [tag][crate::bytes::tag] | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
 //! | [tag_no_case][crate::bytes::tag_no_case] | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
 //! | [take][crate::bytes::take] | `take(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|
-//! | [take_while][crate::bytes::take_while] | `take_while(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided function returns true. `take_while1` does the same, but must return at least one character|
+//! | [take_while][crate::bytes::take_while] | `take_while(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided pattern matches. `take_while1` does the same, but must return at least one character|
 //! | [take_till][crate::bytes::take_till] | `take_till(is_alphabetic)` |  `"123abc"` | `Ok(("abc", "123"))` |Returns the longest list of bytes or characters until the provided function returns true. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(\|c\| !f(c))`|
 //! | [take_until][crate::bytes::take_until] | `take_until("world")` |  `"Hello world"` | `Ok(("world", "Hello "))` |Returns the longest list of bytes or characters until the provided tag is found. `take_until1` does the same, but must return at least one character|
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -14,7 +14,7 @@
 //! | [is_a][crate::bytes::is_a] | ` is_a("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
 //! | [is_not][crate::bytes::is_not] | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
 //! | [one_of][crate::bytes::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
-//! | [none_of][crate::character::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
+//! | [none_of][crate::bytes::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
 //! | [tag][crate::bytes::tag] | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
 //! | [tag_no_case][crate::bytes::tag_no_case] | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
 //! | [take][crate::bytes::take] | `take(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -129,7 +129,7 @@
 //!
 //! - [`alpha0`][crate::character::alpha0]: Recognizes zero or more lowercase and uppercase alphabetic characters: `[a-zA-Z]`. [`alpha1`][crate::character::alpha1] does the same but returns at least one character
 //! - [`alphanumeric0`][crate::character::alphanumeric0]: Recognizes zero or more numerical and alphabetic characters: `[0-9a-zA-Z]`. [`alphanumeric1`][crate::character::alphanumeric1] does the same but returns at least one character
-//! - [`anychar`][crate::character::anychar]: Matches one byte as a character
+//! - [`any`][crate::bytes::any]: Matches one token
 //! - [`crlf`][crate::character::crlf]: Recognizes the string `\r\n`
 //! - [`digit0`][crate::character::digit0]: Recognizes zero or more numerical characters: `[0-9]`. [`digit1`][crate::character::digit1] does the same but returns at least one character
 //! - [`f64`][crate::character::f64]: Recognizes floating point number in a byte string and returns a `f64`

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -11,7 +11,6 @@
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
 //! | [char][crate::character::char] | `char('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) |
-//! | [is_a][crate::bytes::is_a] | ` is_a("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
 //! | [is_not][crate::bytes::is_not] | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
 //! | [one_of][crate::bytes::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
 //! | [none_of][crate::bytes::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -13,7 +13,7 @@
 //! | [char][crate::character::char] | `char('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) |
 //! | [is_a][crate::bytes::is_a] | ` is_a("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
 //! | [is_not][crate::bytes::is_not] | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
-//! | [one_of][crate::character::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
+//! | [one_of][crate::bytes::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
 //! | [none_of][crate::character::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
 //! | [tag][crate::bytes::tag] | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
 //! | [tag_no_case][crate::bytes::tag_no_case] | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
@@ -1172,7 +1172,7 @@ where
 /// Without `cut`:
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult};
-/// # use nom::character::one_of;
+/// # use nom::bytes::one_of;
 /// # use nom::character::digit1;
 /// # use nom::combinator::rest;
 /// # use nom::branch::alt;
@@ -1195,7 +1195,7 @@ where
 /// With `cut`:
 /// ```rust
 /// # use nom::{Err,error::ErrorKind, IResult, error::Error};
-/// # use nom::character::one_of;
+/// # use nom::bytes::one_of;
 /// # use nom::character::digit1;
 /// # use nom::combinator::rest;
 /// # use nom::branch::alt;

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -11,7 +11,6 @@
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
 //! | [char][crate::character::char] | `char('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) |
-//! | [is_not][crate::bytes::is_not] | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
 //! | [one_of][crate::bytes::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
 //! | [none_of][crate::bytes::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
 //! | [tag][crate::bytes::tag] | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|

--- a/src/input.rs
+++ b/src/input.rs
@@ -1507,6 +1507,12 @@ impl<C: AsChar> FindToken<C> for char {
   }
 }
 
+impl<C: AsChar, F: Fn(C) -> bool> FindToken<C> for F {
+  fn find_token(&self, token: C) -> bool {
+    self(token)
+  }
+}
+
 impl<'a> FindToken<u8> for &'a [u8] {
   fn find_token(&self, token: u8) -> bool {
     memchr::memchr(token, self).is_some()

--- a/src/input.rs
+++ b/src/input.rs
@@ -1477,6 +1477,36 @@ where
   }
 }
 
+impl FindToken<u8> for u8 {
+  fn find_token(&self, token: u8) -> bool {
+    *self == token
+  }
+}
+
+impl<'a> FindToken<&'a u8> for u8 {
+  fn find_token(&self, token: &u8) -> bool {
+    self.find_token(*token)
+  }
+}
+
+impl FindToken<char> for u8 {
+  fn find_token(&self, token: char) -> bool {
+    self.as_char() == token
+  }
+}
+
+impl<'a> FindToken<&'a char> for u8 {
+  fn find_token(&self, token: &char) -> bool {
+    self.find_token(*token)
+  }
+}
+
+impl<C: AsChar> FindToken<C> for char {
+  fn find_token(&self, token: C) -> bool {
+    *self == token.as_char()
+  }
+}
+
 impl<'a> FindToken<u8> for &'a [u8] {
   fn find_token(&self, token: u8) -> bool {
     memchr::memchr(token, self).is_some()

--- a/src/input.rs
+++ b/src/input.rs
@@ -1603,6 +1603,45 @@ impl<'a, 'b> FindToken<&'a char> for &'b [char] {
   }
 }
 
+impl<T> FindToken<T> for () {
+  fn find_token(&self, _token: T) -> bool {
+    false
+  }
+}
+
+macro_rules! impl_find_token_for_tuple {
+  ($($haystack:ident),+) => (
+    #[allow(non_snake_case)]
+    impl<T, $($haystack),+> FindToken<T> for ($($haystack),+,)
+    where
+    T: Clone,
+      $($haystack: FindToken<T>),+
+    {
+      fn find_token(&self, token: T) -> bool {
+        let ($(ref $haystack),+,) = *self;
+        $($haystack.find_token(token.clone()) || )+ false
+      }
+    }
+  )
+}
+
+macro_rules! impl_find_token_for_tuples {
+    ($haystack1:ident, $($haystack:ident),+) => {
+        impl_find_token_for_tuples!(__impl $haystack1; $($haystack),+);
+    };
+    (__impl $($haystack:ident),+; $haystack1:ident $(,$haystack2:ident)*) => {
+        impl_find_token_for_tuple!($($haystack),+);
+        impl_find_token_for_tuples!(__impl $($haystack),+, $haystack1; $($haystack2),*);
+    };
+    (__impl $($haystack:ident),+;) => {
+        impl_find_token_for_tuple!($($haystack),+);
+    }
+}
+
+impl_find_token_for_tuples!(
+  F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16, F17, F18, F19, F20, F21
+);
+
 /// Look for a substring in self
 pub trait FindSubstring<T> {
   /// Returns the byte position of the substring if it is found

--- a/src/input.rs
+++ b/src/input.rs
@@ -1491,7 +1491,13 @@ impl<'a, 'b> FindToken<&'a u8> for &'b [u8] {
 
 impl<'a> FindToken<char> for &'a [u8] {
   fn find_token(&self, token: char) -> bool {
-    self.iter().any(|i| *i == token as u8)
+    self.iter().any(|i| i.as_char() == token)
+  }
+}
+
+impl<'a, 'b> FindToken<&'a char> for &'b [u8] {
+  fn find_token(&self, token: &char) -> bool {
+    self.find_token(*token)
   }
 }
 
@@ -1503,6 +1509,18 @@ impl<const LEN: usize> FindToken<u8> for [u8; LEN] {
 
 impl<'a, const LEN: usize> FindToken<&'a u8> for [u8; LEN] {
   fn find_token(&self, token: &u8) -> bool {
+    self.find_token(*token)
+  }
+}
+
+impl<'a, const LEN: usize> FindToken<char> for [u8; LEN] {
+  fn find_token(&self, token: char) -> bool {
+    self.iter().any(|i| i.as_char() == token)
+  }
+}
+
+impl<'a, const LEN: usize> FindToken<&'a char> for [u8; LEN] {
+  fn find_token(&self, token: &char) -> bool {
     self.find_token(*token)
   }
 }
@@ -1522,6 +1540,24 @@ impl<'a, 'b> FindToken<&'a u8> for &'b str {
 impl<'a> FindToken<char> for &'a str {
   fn find_token(&self, token: char) -> bool {
     self.chars().any(|i| i == token)
+  }
+}
+
+impl<'a, 'b> FindToken<&'a char> for &'b str {
+  fn find_token(&self, token: &char) -> bool {
+    self.find_token(*token)
+  }
+}
+
+impl<'a> FindToken<u8> for &'a [char] {
+  fn find_token(&self, token: u8) -> bool {
+    self.iter().any(|i| *i == token.as_char())
+  }
+}
+
+impl<'a, 'b> FindToken<&'a u8> for &'b [char] {
+  fn find_token(&self, token: &u8) -> bool {
+    self.find_token(*token)
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1470,7 +1470,29 @@ impl<'a, const LEN: usize> Compare<[u8; LEN]> for &'a [u8] {
   }
 }
 
-/// Look for a token in self
+/// Check if a token in in a set of possible tokens
+///
+/// This is generally implemented on patterns that a token may match and supports `u8` and `char`
+/// tokens along with the following patterns
+/// - `b'c'` and `'c'`
+/// - `b""` and `""`
+/// - `|c| true`
+/// - `b'a'..=b'z'`, `'a'..='z'` (etc for each [range type][std::ops])
+/// - `(pattern1, pattern2, ...)`
+///
+/// For example, you could implement `hex_digit0` as:
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::ErrorKind, error::Error, Needed};
+/// # use nom::bytes::take_while1;
+/// fn hex_digit1(input: &str) -> IResult<&str, &str> {
+///     take_while1(('a'..='f', 'A'..='F', '0'..='9')).parse(input)
+/// }
+///
+/// assert_eq!(hex_digit1("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(hex_digit1("H2"), Err(Err::Error(Error::new("H2", ErrorKind::TakeWhile1))));
+/// assert_eq!(hex_digit1(""), Err(Err::Error(Error::new("", ErrorKind::TakeWhile1))));
+/// ```
 pub trait FindToken<T> {
   /// Returns true if self contains the token
   fn find_token(&self, token: T) -> bool;

--- a/src/input.rs
+++ b/src/input.rs
@@ -436,7 +436,14 @@ impl AsBytes for str {
 
 /// Transforms common types to a char for basic token parsing
 pub trait AsChar {
-  /// makes a char from self
+  /// Makes a char from self
+  ///
+  /// ```
+  /// use nom::input::AsChar as _;
+  ///
+  /// assert_eq!('a'.as_char(), 'a');
+  /// assert_eq!(u8::MAX.as_char(), std::char::from_u32(u8::MAX as u32).unwrap());
+  /// ```
   fn as_char(self) -> char;
 
   /// Tests that self is an alphabetic character

--- a/src/input.rs
+++ b/src/input.rs
@@ -54,7 +54,9 @@ use core::num::NonZeroUsize;
 
 use crate::error::{ErrorKind, ParseError};
 use crate::lib::std::iter::{Copied, Enumerate};
-use crate::lib::std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use crate::lib::std::ops::{
+  Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 use crate::lib::std::slice::Iter;
 use crate::lib::std::str::from_utf8;
 use crate::lib::std::str::CharIndices;
@@ -1510,6 +1512,49 @@ impl<C: AsChar> FindToken<C> for char {
 impl<C: AsChar, F: Fn(C) -> bool> FindToken<C> for F {
   fn find_token(&self, token: C) -> bool {
     self(token)
+  }
+}
+
+impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for Range<C2> {
+  fn find_token(&self, token: C1) -> bool {
+    let start = self.start.clone().as_char();
+    let end = self.end.clone().as_char();
+    (start..end).contains(&token.as_char())
+  }
+}
+
+impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeInclusive<C2> {
+  fn find_token(&self, token: C1) -> bool {
+    let start = self.start().clone().as_char();
+    let end = self.end().clone().as_char();
+    (start..=end).contains(&token.as_char())
+  }
+}
+
+impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeFrom<C2> {
+  fn find_token(&self, token: C1) -> bool {
+    let start = self.start.clone().as_char();
+    (start..).contains(&token.as_char())
+  }
+}
+
+impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeTo<C2> {
+  fn find_token(&self, token: C1) -> bool {
+    let end = self.end.clone().as_char();
+    (..end).contains(&token.as_char())
+  }
+}
+
+impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeToInclusive<C2> {
+  fn find_token(&self, token: C1) -> bool {
+    let end = self.end.clone().as_char();
+    (..=end).contains(&token.as_char())
+  }
+}
+
+impl<C1: AsChar> FindToken<C1> for RangeFull {
+  fn find_token(&self, _token: C1) -> bool {
+    true
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,11 @@
 //!   sequence::delimited,
 //!   // see the "streaming/complete" paragraph lower for an explanation of these submodules
 //!   character::char,
-//!   bytes::is_not
+//!   bytes::take_till1
 //! };
 //!
 //! fn parens(input: &str) -> IResult<&str, &str> {
-//!   delimited(char('('), is_not(")"), char(')'))(input)
+//!   delimited(char('('), take_till1(")"), char(')'))(input)
 //! }
 //! ```
 //!

--- a/src/str.rs
+++ b/src/str.rs
@@ -5,7 +5,7 @@ mod test {
   #[cfg(feature = "alloc")]
   use crate::{branch::alt, bytes::tag_no_case, multi::many1};
   use crate::{
-    bytes::{is_a, is_not, tag, take, take_till, take_until},
+    bytes::{is_not, tag, take, take_till, take_until, take_while1},
     error::{self, ErrorKind},
     Err, IResult,
   };
@@ -177,9 +177,7 @@ mod test {
   }
 
   #[test]
-  fn take_while1() {
-    use crate::bytes::take_while1;
-
+  fn test_take_while1() {
     fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
       take_while1(is_alphabetic)(i)
     }
@@ -426,7 +424,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřèÂßÇ";
     const LEFTOVER: &str = "áƒƭèř";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_a(MATCH)(input)
+      take_while1(MATCH)(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -476,7 +474,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &str = "Ûñℓúçƙ¥";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_a(MATCH)(input)
+      take_while1(MATCH)(input)
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),

--- a/src/str.rs
+++ b/src/str.rs
@@ -5,7 +5,7 @@ mod test {
   #[cfg(feature = "alloc")]
   use crate::{branch::alt, bytes::tag_no_case, multi::many1};
   use crate::{
-    bytes::{is_not, tag, take, take_till, take_until, take_while1},
+    bytes::{tag, take, take_till, take_till1, take_until, take_while1},
     error::{self, ErrorKind},
     Err, IResult,
   };
@@ -273,7 +273,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřèÂßÇ";
     const LEFTOVER: &str = "áƒƭèř";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_not(AVOID)(input)
+      take_till1(AVOID)(input)
     }
     match test(INPUT) {
       Ok((extra, output)) => {
@@ -345,7 +345,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &str = "βúçƙ¥";
     fn test(input: &str) -> IResult<&str, &str> {
-      is_not(AVOID)(input)
+      take_till1(AVOID)(input)
     }
     match test(INPUT) {
       Err(Err::Error(_)) => (),

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -1,6 +1,6 @@
 use nom::bytes::escaped;
+use nom::bytes::one_of;
 use nom::character::digit1;
-use nom::character::one_of;
 use nom::{error::ErrorKind, Err, IResult};
 
 fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,6 +1,6 @@
 use nom::prelude::*;
 use nom::{
-  bytes::{is_a, tag, take_till, take_while},
+  bytes::{tag, take_till, take_while, take_while1},
   character::{alphanumeric1 as alphanumeric, char, space0 as space},
   combinator::opt,
   multi::many0,
@@ -18,13 +18,13 @@ fn not_line_ending(i: &str) -> IResult<&str, &str> {
 }
 
 fn space_or_line_ending(i: &str) -> IResult<&str, &str> {
-  is_a(" \r\n")(i)
+  take_while1(" \r\n")(i)
 }
 
 fn category(i: &str) -> IResult<&str, &str> {
   terminated(
     delimited(char('['), take_while(|c| c != ']'), char(']')),
-    opt(is_a(" \r\n")),
+    opt(take_while1(" \r\n")),
   )(i)
 }
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -127,10 +127,10 @@ fn issue_655() {
 
 #[cfg(feature = "alloc")]
 fn issue_717(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-  use nom::bytes::{is_not, tag};
+  use nom::bytes::{tag, take_till1};
   use nom::multi::separated_list0;
 
-  separated_list0(tag([0x0]), is_not([0x0u8]))(i)
+  separated_list0(tag([0x0]), take_till1([0x0u8]))(i)
 }
 
 mod issue_647 {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -234,7 +234,7 @@ fn issue_1231_bits_expect_fn_closure() {
 
 #[test]
 fn issue_1282_findtoken_char() {
-  use nom::character::one_of;
+  use nom::bytes::one_of;
   use nom::error::Error;
   let parser = one_of::<_, _, Error<_>, false>(&['a', 'b', 'c'][..]);
   assert_eq!(parser("aaa"), Ok(("aa", 'a')));

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -2,8 +2,8 @@
 
 use nom::{
   branch::alt,
-  bytes::{tag, take},
-  character::{anychar, char, f64, multispace0, none_of},
+  bytes::{none_of, tag, take},
+  character::{anychar, char, f64, multispace0},
   error::ParseError,
   multi::{fold_many0, separated_list0},
   sequence::{delimited, preceded, separated_pair},

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -2,8 +2,8 @@
 
 use nom::{
   branch::alt,
-  bytes::{none_of, tag, take},
-  character::{anychar, char, f64, multispace0},
+  bytes::{any, none_of, tag, take},
+  character::{char, f64, multispace0},
   error::ParseError,
   multi::{fold_many0, separated_list0},
   sequence::{delimited, preceded, separated_pair},
@@ -58,7 +58,7 @@ fn character(input: &str) -> IResult<&str, char> {
   let (input, c) = none_of("\"")(input)?;
   if c == '\\' {
     alt((
-      anychar.map_res(|c| {
+      any.map_res(|c| {
         Ok(match c {
           '"' | '\\' | '/' => c,
           'b' => '\x08',

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -3,7 +3,7 @@
 
 use std::str;
 
-use nom::bytes::is_not;
+use nom::bytes::take_till1;
 use nom::character::char;
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -12,7 +12,7 @@ use nom::IResult;
 
 fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
   move |input| {
-    is_not(" \t\r\n")
+    take_till1(" \t\r\n")
       .map_res(str::from_utf8)
       .map(ToString::to_string)
       .parse(input)


### PR DESCRIPTION
Currently, nom tries to offer one of every type of API (bytes vs char, one of vs many of, list vs predicate)

This expands `FindToken` to at least reduce the "list vs predicate" option by expanding on "list" patterns to also include ranges, single tokens, predicates, or even compound patterns using tuples.  This allowed us to replace `is_a` with `take_while1`, `is_not` with `take_till1`, and `satisfy` with `one_of`.  `char` being replaced by `one_of` was split out into #45.

In a related fashion, we simplified the offerings by making some char-specific predicates char/byte agnostic, including `anychar` (as `any`), `one_of`, and `none_of`.

Fixes Geal/nom#1580