### PR TITLE
feat(parser): impl Parsers for literals

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -64,10 +64,7 @@ fn main() {
   // - we can get the remaining input afterwards, like with the `try_fold` trick
   let mut nom_it = iterator(
     data,
-    terminated(
-      separated_pair(alphanumeric1, tag(":"), alphanumeric1),
-      tag(","),
-    ),
+    terminated(separated_pair(alphanumeric1, ":", alphanumeric1), ","),
   );
 
   let res = nom_it

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -5,7 +5,7 @@ use nom::{
   branch::alt,
   bytes::one_of,
   bytes::{escaped, tag, take_while},
-  character::{alphanumeric1 as alphanumeric, char, f64},
+  character::{alphanumeric1 as alphanumeric, f64},
   combinator::{cut, opt},
   error::{convert_error, ContextError, ErrorKind, ParseError, VerboseError},
   multi::separated_list0,
@@ -95,7 +95,7 @@ fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {
 fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-  preceded(char('\"'), cut(terminated(parse_str, char('\"'))))
+  preceded('\"', cut(terminated(parse_str, '\"')))
     .context("string")
     .parse(i)
 }
@@ -108,10 +108,10 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, Vec<JsonValue>, E> {
   preceded(
-    char('['),
+    '[',
     cut(terminated(
-      separated_list0(preceded(sp, char(',')), json_value),
-      preceded(sp, char(']')),
+      separated_list0(preceded(sp, ','), json_value),
+      preceded(sp, ']'),
     )),
   )
   .context("array")
@@ -121,26 +121,22 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, (&'a str, JsonValue), E> {
-  separated_pair(
-    preceded(sp, string),
-    cut(preceded(sp, char(':'))),
-    json_value,
-  )(i)
+  separated_pair(preceded(sp, string), cut(preceded(sp, ':')), json_value)(i)
 }
 
 fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   i: &'a str,
 ) -> IResult<&'a str, HashMap<String, JsonValue>, E> {
   preceded(
-    char('{'),
+    '{',
     cut(terminated(
-      separated_list0(preceded(sp, char(',')), key_value).map(|tuple_vec| {
+      separated_list0(preceded(sp, ','), key_value).map(|tuple_vec| {
         tuple_vec
           .into_iter()
           .map(|(k, v)| (String::from(k), v))
           .collect()
       }),
-      preceded(sp, char('}')),
+      preceded(sp, '}'),
     )),
   )
   .context("map")

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -5,7 +5,7 @@ use nom::{
   branch::alt,
   bytes::one_of,
   bytes::{escaped, tag, take_while},
-  character::{alphanumeric1 as alphanumeric, char, f64},
+  character::{alphanumeric1 as alphanumeric, f64},
   combinator::cut,
   error::ParseError,
   multi::separated_list0,
@@ -227,7 +227,7 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 }
 
 fn string<'a>(i: &'a str) -> IResult<&'a str, &'a str> {
-  preceded(char('\"'), cut(terminated(parse_str, char('\"'))))
+  preceded('\"', cut(terminated(parse_str, '\"')))
     .context("string")
     .parse(i)
 }
@@ -238,10 +238,10 @@ fn boolean<'a>(input: &'a str) -> IResult<&'a str, bool> {
 
 fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
   preceded(
-    char('['),
+    '[',
     cut(terminated(
-      separated_list0(preceded(sp, char(',')), value).map(|_| ()),
-      preceded(sp, char(']')),
+      separated_list0(preceded(sp, ','), value).map(|_| ()),
+      preceded(sp, ']'),
     )),
   )
   .context("array")
@@ -249,15 +249,15 @@ fn array<'a>(i: &'a str) -> IResult<&'a str, ()> {
 }
 
 fn key_value<'a>(i: &'a str) -> IResult<&'a str, (&'a str, ())> {
-  separated_pair(preceded(sp, string), cut(preceded(sp, char(':'))), value)(i)
+  separated_pair(preceded(sp, string), cut(preceded(sp, ':')), value)(i)
 }
 
 fn hash<'a>(i: &'a str) -> IResult<&'a str, ()> {
   preceded(
-    char('{'),
+    '{',
     cut(terminated(
-      separated_list0(preceded(sp, char(',')), key_value).map(|_| ()),
-      preceded(sp, char('}')),
+      separated_list0(preceded(sp, ','), key_value).map(|_| ()),
+      preceded(sp, '}'),
     )),
   )
   .context("map")

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -8,7 +8,7 @@ use nom::{
   branch::alt,
   bytes::one_of,
   bytes::tag,
-  character::{alpha1, char, digit1, multispace0, multispace1},
+  character::{alpha1, digit1, multispace0, multispace1},
   combinator::{cut, opt},
   error::VerboseError,
   multi::many0,
@@ -155,9 +155,9 @@ where
   F: Parser<&'a str, O1, VerboseError<&'a str>>,
 {
   delimited(
-    char('('),
+    '(',
     preceded(multispace0, inner),
-    cut(preceded(multispace0, char(')'))).context("closing paren"),
+    cut(preceded(multispace0, ')')).context("closing paren"),
   )
 }
 

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -108,10 +108,10 @@ fn parse_bool<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
 /// We introduce some error handling combinators: `context` for human readable errors
 /// and `cut` to prevent back-tracking.
 ///
-/// Put plainly: `preceded(tag(":"), cut(alpha1))` means that once we see the `:`
+/// Put plainly: `preceded(":", cut(alpha1))` means that once we see the `:`
 /// character, we have to see one or more alphabetic chararcters or the input is invalid.
 fn parse_keyword<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
-  preceded(tag(":"), cut(alpha1))
+  preceded(":", cut(alpha1))
     .context("keyword")
     .map(|sym_str: &str| Atom::Keyword(sym_str.to_string()))
     .parse(i)
@@ -122,8 +122,7 @@ fn parse_keyword<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>
 fn parse_num<'a>(i: &'a str) -> IResult<&'a str, Atom, VerboseError<&'a str>> {
   alt((
     digit1.map_res(|digit_str: &str| digit_str.parse::<i32>().map(Atom::Num)),
-    preceded(tag("-"), digit1)
-      .map(|digit_str: &str| Atom::Num(-1 * digit_str.parse::<i32>().unwrap())),
+    preceded("-", digit1).map(|digit_str: &str| Atom::Num(-1 * digit_str.parse::<i32>().unwrap())),
   ))(i)
 }
 
@@ -188,7 +187,7 @@ fn parse_if<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
     // here to avoid ambiguity with other names starting with `if`, if we added
     // variables to our language, we say that if must be terminated by at least
     // one whitespace character
-    terminated(tag("if"), multispace1),
+    terminated("if", multispace1),
     cut((parse_expr, parse_expr, opt(parse_expr))),
   )
   .map(|(pred, true_branch, maybe_false_branch)| {
@@ -215,7 +214,7 @@ fn parse_quote<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> 
   // this should look very straight-forward after all we've done:
   // we find the `'` (quote) character, use cut to say that we're unambiguously
   // looking for an s-expression of 0 or more expressions, and then parse them
-  preceded(tag("'"), cut(s_exp(many0(parse_expr))))
+  preceded("'", cut(s_exp(many0(parse_expr))))
     .context("quote")
     .map(|exprs| Expr::Quote(exprs))
     .parse(i)

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -13,7 +13,8 @@
 
 use nom::branch::alt;
 use nom::bytes::{take_till1, take_while_m_n};
-use nom::character::{char, multispace1};
+use nom::character::char;
+use nom::character::multispace1;
 use nom::error::{FromExternalError, ParseError};
 use nom::multi::fold_many0;
 use nom::prelude::*;
@@ -38,11 +39,11 @@ where
   // `preceded` takes a prefix parser, and if it succeeds, returns the result
   // of the body parser. In this case, it parses u{XXXX}.
   let parse_delimited_hex = preceded(
-    char('u'),
+    'u',
     // `delimited` is like `preceded`, but it parses both a prefix and a suffix.
     // It returns the result of the middle parser. In this case, it parses
     // {XXXX}, where XXXX is 1 to 6 hex numerals, and returns XXXX
-    delimited(char('{'), parse_hex, char('}')),
+    delimited('{', parse_hex, '}'),
   );
 
   // `map_res` takes the result of a parser and applies a function that returns
@@ -65,7 +66,7 @@ where
   E: ParseError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
   preceded(
-    char('\\'),
+    '\\',
     // `alt` tries each parser in sequence, returning the result of
     // the first successful match
     alt((
@@ -91,7 +92,7 @@ where
 fn parse_escaped_whitespace<'a, E: ParseError<&'a str>>(
   input: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-  preceded(char('\\'), multispace1)(input)
+  preceded('\\', multispace1)(input)
 }
 
 /// Parse a non-empty block of text that doesn't include \ or "
@@ -161,7 +162,7 @@ where
   // " character, the closing delimiter " would never match. When using
   // `delimited` with a looping parser (like fold_many0), be sure that the
   // loop won't accidentally match your closing delimiter!
-  delimited(char('"'), build_string, char('"'))(input)
+  delimited('"', build_string, '"')(input)
 }
 
 fn main() {

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -70,7 +70,7 @@
 //!
 //! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E>
 //! {
-//!   pair(char('%'), take_till1("\n\r"))
+//!   pair('%', take_till1("\n\r"))
 //!     .value(()) // Output is thrown away.
 //!     .parse(i)
 //! }
@@ -173,7 +173,7 @@
 //!   preceded(
 //!     alt((tag("0x"), tag("0X"))),
 //!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
 //!     ).recognize()
 //!   )(input)
 //! }
@@ -197,7 +197,7 @@
 //!   preceded(
 //!     alt((tag("0x"), tag("0X"))),
 //!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0(char('_')))
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
 //!     ).recognize()
 //!   ).map_res(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
@@ -222,7 +222,7 @@
 //!   preceded(
 //!     alt((tag("0o"), tag("0O"))),
 //!     many1(
-//!       terminated(one_of("01234567"), many0(char('_')))
+//!       terminated(one_of("01234567"), many0('_'))
 //!     ).recognize()
 //!   )(input)
 //! }
@@ -245,7 +245,7 @@
 //!   preceded(
 //!     alt((tag("0b"), tag("0B"))),
 //!     many1(
-//!       terminated(one_of("01"), many0(char('_')))
+//!       terminated(one_of("01"), many0('_'))
 //!     ).recognize()
 //!   )(input)
 //! }
@@ -265,7 +265,7 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   many1(
-//!     terminated(one_of("0123456789"), many0(char('_')))
+//!     terminated(one_of("0123456789"), many0('_'))
 //!   )
 //!     .recognize()
 //!     .parse(input)
@@ -291,7 +291,7 @@
 //!   alt((
 //!     // Case one: .42
 //!     (
-//!       char('.'),
+//!       '.',
 //!       decimal,
 //!       opt((
 //!         one_of("eE"),
@@ -303,7 +303,7 @@
 //!     (
 //!       decimal,
 //!       opt(preceded(
-//!         char('.'),
+//!         '.',
 //!         decimal,
 //!       )),
 //!       one_of("eE"),
@@ -313,7 +313,7 @@
 //!     , // Case three: 42. and 42.42
 //!     (
 //!       decimal,
-//!       char('.'),
+//!       '.',
 //!       opt(decimal)
 //!     ).recognize()
 //!   ))(input)
@@ -321,7 +321,7 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   many1(
-//!     terminated(one_of("0123456789"), many0(char('_')))
+//!     terminated(one_of("0123456789"), many0('_'))
 //!   )
 //!     .recognize()
 //!     .parse(input)

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -91,9 +91,9 @@
 //!
 //! pub fn pinline_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E> {
 //!   (
-//!     tag("(*"),
+//!     "(*",
 //!     take_until("*)"),
-//!     tag("*)")
+//!     "*)"
 //!   )
 //!     .value(()) // Output is thrown away.
 //!     .parse(i)
@@ -120,8 +120,8 @@
 //!
 //! pub fn identifier(input: &str) -> IResult<&str, &str> {
 //!   pair(
-//!     alt((alpha1, tag("_"))),
-//!     many0_count(alt((alphanumeric1, tag("_"))))
+//!     alt((alpha1, "_")),
+//!     many0_count(alt((alphanumeric1, "_")))
 //!   )
 //!      .recognize()
 //!      .parse(input)
@@ -171,7 +171,7 @@
 //!
 //! fn hexadecimal(input: &str) -> IResult<&str, &str> { // <'a, E: ParseError<&'a str>>
 //!   preceded(
-//!     alt((tag("0x"), tag("0X"))),
+//!     alt(("0x", "0X")),
 //!     many1(
 //!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
 //!     ).recognize()
@@ -195,7 +195,7 @@
 //!
 //! fn hexadecimal_value(input: &str) -> IResult<&str, i64> {
 //!   preceded(
-//!     alt((tag("0x"), tag("0X"))),
+//!     alt(("0x", "0X")),
 //!     many1(
 //!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
 //!     ).recognize()
@@ -220,7 +220,7 @@
 //!
 //! fn octal(input: &str) -> IResult<&str, &str> {
 //!   preceded(
-//!     alt((tag("0o"), tag("0O"))),
+//!     alt(("0o", "0O")),
 //!     many1(
 //!       terminated(one_of("01234567"), many0('_'))
 //!     ).recognize()
@@ -243,7 +243,7 @@
 //!
 //! fn binary(input: &str) -> IResult<&str, &str> {
 //!   preceded(
-//!     alt((tag("0b"), tag("0B"))),
+//!     alt(("0b", "0B")),
 //!     many1(
 //!       terminated(one_of("01"), many0('_'))
 //!     ).recognize()

--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -118,14 +118,13 @@
 //!   let space = take_while1(|c| c == b' ');
 //!   let url = take_while1(|c| c != b' ');
 //!   let is_version = |c| c >= b'0' && c <= b'9' || c == b'.';
-//!   let http = tag("HTTP/");
 //!   let version = take_while1(is_version);
 //!   let line_ending = tag("\r\n");
 //!
 //!   // combine http and version to extract the version string
 //!   // preceded will return the result of the second parser
 //!   // if both succeed
-//!   let http_version = preceded(http, version);
+//!   let http_version = preceded("HTTP/", version);
 //!
 //!   // tuples takes as argument a tuple of parsers and will return
 //!   // a tuple of their results

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -93,7 +93,7 @@ pub trait Permutation<I, O, E> {
 /// use nom::character::{char};
 ///
 /// fn parser(input: &str) -> IResult<&str, (char, char)> {
-///   permutation((any, char('a')))(input)
+///   permutation((any, 'a'))(input)
 /// }
 ///
 /// // any parses 'b', then char('a') parses 'a'

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -58,11 +58,13 @@ where
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
 ///
-/// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience
+/// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience (complete
+/// only)
 ///
 /// # Example
 /// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed};
 /// use nom::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -165,6 +167,11 @@ where
 
 /// Returns a token that matches the [pattern][FindToken]
 ///
+/// **Note:** [`Parser`] is implemented as a convenience (complete
+/// only) for
+/// - `u8`
+/// - Ranges of `u8` and `char`
+///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
@@ -179,12 +186,19 @@ where
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
 ///
-/// fn parser(i: &str) -> IResult<&str, char> {
+/// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::OneOf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser_fn("cd"), Err(Err::Error(Error::new("cd", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+///
+/// fn parser_range_literal(i: &str) -> IResult<&str, char> {
+///     ('a'..='b').parse(i)
+/// }
+/// assert_eq!(parser_range_literal("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser_range_literal("cd"), Err(Err::Error(Error::new("cd", ErrorKind::OneOf))));
+/// assert_eq!(parser_range_literal(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// ```
@@ -196,12 +210,12 @@ where
 /// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("bc")), Err(Err::Error((Streaming("bc"), ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 ///
-/// fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
+/// fn parser_fn(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
-/// assert_eq!(parser(Streaming("abc")), Ok((Streaming("bc"), 'a')));
-/// assert_eq!(parser(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
-/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser_fn(Streaming("abc")), Ok((Streaming("bc"), 'a')));
+/// assert_eq!(parser_fn(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -834,7 +834,8 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::ErrorKind, Needed};
 /// # use std::str::from_utf8;
 /// use nom::bytes::{escaped_transform, tag};
 /// use nom::character::alpha1;
@@ -846,9 +847,9 @@ where
 ///     alpha1,
 ///     '\\',
 ///     alt((
-///       value("\\", tag("\\")),
-///       value("\"", tag("\"")),
-///       value("\n", tag("n")),
+///       tag("\\").value("\\"),
+///       tag("\"").value("\""),
+///       tag("n").value("\n"),
 ///     ))
 ///   )(input)
 /// }
@@ -858,7 +859,8 @@ where
 /// ```
 ///
 /// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::ErrorKind, Needed};
 /// # use std::str::from_utf8;
 /// # use nom::input::Streaming;
 /// use nom::bytes::{escaped_transform, tag};
@@ -871,9 +873,9 @@ where
 ///     alpha1,
 ///     '\\',
 ///     alt((
-///       value("\\", tag("\\")),
-///       value("\"", tag("\"")),
-///       value("\n", tag("n")),
+///       tag("\\").value("\\"),
+///       tag("\"").value("\""),
+///       tag("n").value("\n"),
 ///     ))
 ///   )(input)
 /// }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -57,6 +57,9 @@ where
 /// the input that matches the argument
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+///
+/// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience
+///
 /// # Example
 /// ```rust
 /// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -42,14 +42,13 @@ fn complete_escaped_hang_1118() {
   // issue ##1118 escaped does not work with empty string
   fn unquote<'a>(input: &'a str) -> IResult<&'a str, &'a str> {
     use crate::bytes::one_of;
-    use crate::character::*;
     use crate::combinator::opt;
     use crate::sequence::delimited;
 
     delimited(
-      char('"'),
+      '"',
       escaped(opt(none_of(r#"\""#)), '\\', one_of(r#"\"rnt"#)),
-      char('"'),
+      '"',
     )(input)
   }
 

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -20,6 +20,8 @@ use crate::IResult;
 
 /// Recognizes one character.
 ///
+/// **Note:** [`Parser`][crate::Parser] is implemented for `char` literals` as a convenience (complete only)
+///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
@@ -27,10 +29,24 @@ use crate::IResult;
 /// # Example
 ///
 /// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, IResult};
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
 /// # use nom::character::char;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     char('a')(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```
+/// or
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     'a'.parse(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
 /// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -360,7 +360,7 @@ mod complete {
 
   fn digit_to_i16(input: &str) -> IResult<&str, i16> {
     let i = input;
-    let (i, opt_sign) = opt(alt((char('+'), char('-'))))(i)?;
+    let (i, opt_sign) = opt(alt(('+', '-')))(i)?;
     let sign = match opt_sign {
       Some('+') => true,
       Some('-') => false,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -990,7 +990,7 @@ where
 /// use nom::sequence::separated_pair;
 /// # fn main() {
 ///
-/// let mut parser = recognize(separated_pair(alpha1, char(','), alpha1));
+/// let mut parser = recognize(separated_pair(alpha1, ',', alpha1));
 ///
 /// assert_eq!(parser("abcd,efgh"), Ok(("", "abcd,efgh")));
 /// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
@@ -1081,7 +1081,7 @@ where
 ///
 /// # fn main() {
 ///
-/// let mut consumed_parser = consumed(value(true, separated_pair(alpha1, char(','), alpha1)));
+/// let mut consumed_parser = consumed(value(true, separated_pair(alpha1, ',', alpha1)));
 ///
 /// assert_eq!(consumed_parser("abcd,efgh1"), Ok(("1", ("abcd,efgh", true))));
 /// assert_eq!(consumed_parser("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
@@ -1420,7 +1420,7 @@ enum State<E> {
 /// let mut parser = success::<_,_,(_,ErrorKind)>(10);
 /// assert_eq!(parser("xyz"), Ok(("xyz", 10)));
 ///
-/// let mut sign = alt((value(-1, char('-')), value(1, char('+')), success::<_,_,(_,ErrorKind)>(1)));
+/// let mut sign = alt((value(-1, '-'), value(1, '+'), success::<_,_,(_,ErrorKind)>(1)));
 /// assert_eq!(sign("+10"), Ok(("10", 1)));
 /// assert_eq!(sign("-10"), Ok(("10", -1)));
 /// assert_eq!(sign("10"), Ok(("10", 1)));

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,7 +184,7 @@
 //! # let i = " ";
 //! context(
 //!   "string",
-//!   preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
+//!   preceded('\"', cut(terminated(parse_str, '\"'))),
 //! )(i);
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //! };
 //!
 //! fn parens(input: &str) -> IResult<&str, &str> {
-//!   delimited(char('('), take_till1(")"), char(')'))(input)
+//!   delimited('(', take_till1(")"), ')')(input)
 //! }
 //! ```
 //!

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,7 @@ use crate::error::{self, Context, ErrorKind, ParseError};
 use crate::input::InputIsStreaming;
 use crate::input::*;
 use crate::lib::std::fmt;
+use crate::lib::std::ops::RangeFrom;
 use core::num::NonZeroUsize;
 
 /// Holds the result of parsing functions
@@ -751,6 +752,59 @@ where
 {
   fn parse(&mut self, i: I) -> IResult<I, O, E> {
     self(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &[u8]) -> IResult<&[u8], u8> {
+///     b'a'.parse(i)
+/// }
+/// assert_eq!(parser(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
+/// assert_eq!(parser(&b" abc"[..]), Err(Err::Error(Error::new(&b" abc"[..], ErrorKind::OneOf))));
+/// assert_eq!(parser(&b"bc"[..]), Err(Err::Error(Error::new(&b"bc"[..], ErrorKind::OneOf))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&b""[..], ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, u8, E> for u8
+where
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<false>,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, u8, E> {
+    crate::bytes::one_of(*self).parse(i)
+  }
+}
+
+/// This is a shortcut for [`char`][crate::character::char].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     'a'.parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```
+impl<I, E> Parser<I, char, E> for char
+where
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, char, E> {
+    crate::character::char(*self).parse(i)
   }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -409,7 +409,7 @@ pub trait Parser<I, O, E> {
   /// use nom::sequence::separated_pair;
   /// # fn main() {
   ///
-  /// let mut parser = separated_pair(alpha1, char(','), alpha1).recognize();
+  /// let mut parser = separated_pair(alpha1, ',', alpha1).recognize();
   ///
   /// assert_eq!(parser.parse("abcd,efgh"), Ok(("", "abcd,efgh")));
   /// assert_eq!(parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
@@ -446,7 +446,7 @@ pub trait Parser<I, O, E> {
   ///
   /// # fn main() {
   ///
-  /// let mut consumed_parser = separated_pair(alpha1, char(','), alpha1).value(true).with_recognized();
+  /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_recognized();
   ///
   /// assert_eq!(consumed_parser.parse("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
   /// assert_eq!(consumed_parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,6 +6,7 @@ use crate::combinator::*;
 use crate::error::DbgErr;
 use crate::error::{self, Context, ErrorKind, ParseError};
 use crate::input::InputIsStreaming;
+use crate::input::*;
 use crate::lib::std::fmt;
 use core::num::NonZeroUsize;
 
@@ -750,6 +751,91 @@ where
 {
   fn parse(&mut self, i: I) -> IResult<I, O, E> {
     self(i)
+  }
+}
+
+/// This is a shortcut for [`tag`][crate::bytes::tag].
+///
+/// # Example
+/// ```rust
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed};
+/// # use nom::branch::alt;
+/// # use nom::bytes::take;
+///
+/// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   alt((&"Hello"[..], take(5usize))).parse(s)
+/// }
+///
+/// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
+/// assert_eq!(parser(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
+/// assert_eq!(parser(&b"Some"[..]), Err(Err::Error(Error::new(&b"Some"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&b""[..], ErrorKind::Eof))));
+/// ```
+impl<'s, I, E: ParseError<I>> Parser<I, <I as IntoOutput>::Output, E> for &'s [u8]
+where
+  I: InputTake + InputLength + Compare<&'s [u8]> + InputIsStreaming<false>,
+  I: IntoOutput,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
+    crate::bytes::tag(*self).parse(i)
+  }
+}
+
+/// This is a shortcut for [`tag`][crate::bytes::tag].
+///
+/// # Example
+/// ```rust
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed};
+/// # use nom::branch::alt;
+/// # use nom::bytes::take;
+///
+/// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   alt((b"Hello", take(5usize))).parse(s)
+/// }
+///
+/// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
+/// assert_eq!(parser(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
+/// assert_eq!(parser(&b"Some"[..]), Err(Err::Error(Error::new(&b"Some"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&b""[..], ErrorKind::Eof))));
+/// ```
+impl<'s, I, E: ParseError<I>, const N: usize> Parser<I, <I as IntoOutput>::Output, E>
+  for &'s [u8; N]
+where
+  I: InputTake + InputLength + Compare<&'s [u8; N]> + InputIsStreaming<false>,
+  I: IntoOutput,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
+    crate::bytes::tag(*self).parse(i)
+  }
+}
+
+/// This is a shortcut for [`tag`][crate::bytes::tag].
+///
+/// # Example
+/// ```rust
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{Error, ErrorKind}, Needed};
+/// # use nom::branch::alt;
+/// # use nom::bytes::take;
+///
+/// fn parser(s: &str) -> IResult<&str, &str> {
+///   alt(("Hello", take(5usize))).parse(s)
+/// }
+///
+/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser("Something"), Ok(("hing", "Somet")));
+/// assert_eq!(parser("Some"), Err(Err::Error(Error::new("Some", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```
+impl<'s, I, E: ParseError<I>> Parser<I, <I as IntoOutput>::Output, E> for &'s str
+where
+  I: InputTake + InputLength + Compare<&'s str> + InputIsStreaming<false>,
+  I: IntoOutput,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
+    crate::bytes::tag(*self).parse(i)
   }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,9 @@ use crate::error::{self, Context, ErrorKind, ParseError};
 use crate::input::InputIsStreaming;
 use crate::input::*;
 use crate::lib::std::fmt;
-use crate::lib::std::ops::RangeFrom;
+use crate::lib::std::ops::{
+  Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 use core::num::NonZeroUsize;
 
 /// Holds the result of parsing functions
@@ -890,6 +892,173 @@ where
 {
   fn parse(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
     crate::bytes::tag(*self).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     ('a'..='d').parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("def"), Ok(("ef", 'd')));
+/// assert_eq!(parser("efg"), Err(Err::Error(Error::new("efg", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for RangeInclusive<<I as InputIter>::Item>
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     ('d'..).parse(i)
+/// }
+/// assert_eq!(parser("def"), Ok(("ef", 'd')));
+/// assert_eq!(parser("efg"), Ok(("fg", 'e')));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for RangeFrom<<I as InputIter>::Item>
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     (..'d').parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("bc"), Ok(("c", 'b')));
+/// assert_eq!(parser("def"), Err(Err::Error(Error::new("def", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for RangeTo<<I as InputIter>::Item>
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     (..='d').parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("def"), Ok(("ef", 'd')));
+/// assert_eq!(parser("efg"), Err(Err::Error(Error::new("efg", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for RangeToInclusive<<I as InputIter>::Item>
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     ('a'..'d').parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("bc"), Ok(("c", 'b')));
+/// assert_eq!(parser("def"), Err(Err::Error(Error::new("def", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for Range<<I as InputIter>::Item>
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
+  }
+}
+
+/// This is a shortcut for [`one_of`][crate::bytes::one_of].
+///
+/// # Example
+///
+/// ```
+/// # use nom::prelude::*;
+/// # use nom::{Err, error::{ErrorKind, Error}};
+/// # use nom::character::char;
+/// fn parser(i: &str) -> IResult<&str, char> {
+///     (..).parse(i)
+/// }
+/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
+/// assert_eq!(parser("bc"), Ok(("c", 'b')));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// ```
+impl<I, E> Parser<I, <I as InputIter>::Item, E> for RangeFull
+where
+  Self: Clone,
+  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  <I as InputIter>::Item: Copy + AsChar,
+  E: ParseError<I>,
+{
+  fn parse(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
+    crate::bytes::one_of(self.clone()).parse(i)
   }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,6 +320,41 @@ where
 }
 
 /// All nom parsers implement this trait
+///
+/// The simplest way to implement a `Parser` is with a function
+/// ```rust
+/// use nom::prelude::*;
+///
+/// fn success(input: &str) -> IResult<&str, ()> {
+///     let output = ();
+///     Ok((input, output))
+/// }
+///
+/// let (input, output) = success.parse("Hello").unwrap();
+/// assert_eq!(input, "Hello");  // We didn't consume any input
+/// ```
+///
+/// which can be made stateful by returning a function
+/// ```rust
+/// use nom::prelude::*;
+///
+/// fn success<O: Clone>(output: O) -> impl FnMut(&str) -> IResult<&str, O> {
+///     move |input: &str| {
+///         let output = output.clone();
+///         Ok((input, output))
+///     }
+/// }
+///
+/// let (input, output) = success("World").parse("Hello").unwrap();
+/// assert_eq!(input, "Hello");  // We didn't consume any input
+/// assert_eq!(output, "World");
+/// ```
+///
+/// Additionally, some basic types implement `Parser` as well, including
+/// - `char`, see [`nom::character::char`][crate::character::char]
+/// - `u8`, see [`nom::character::char`][crate::bytes::one_of]
+/// - `&[u8]` and `&str`, see [`nom::character::char`][crate::bytes::tag]
+/// - Ranges of `char` or `u8`, see [`nom::character::char`][crate::bytes::one_of]
 pub trait Parser<I, O, E> {
   /// A parser takes in input type, and returns a `Result` containing
   /// either the remaining input and the output value, or an error

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -1,7 +1,6 @@
 use nom::prelude::*;
 use nom::{
   branch::alt,
-  bytes::tag,
   character::{digit1 as digit, space0 as space},
   multi::fold_many0,
   sequence::delimited,
@@ -14,7 +13,7 @@ use std::str::FromStr;
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
 fn parens(i: &str) -> IResult<&str, i64> {
-  delimited(space, delimited(tag("("), expr, tag(")")), space)(i)
+  delimited(space, delimited("(", expr, ")"), space)(i)
 }
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -2,7 +2,6 @@ use nom::prelude::*;
 use nom::{
   branch::alt,
   bytes::tag,
-  character::char,
   character::{digit1 as digit, space0 as space},
   multi::fold_many0,
   sequence::delimited,
@@ -36,7 +35,7 @@ fn term(i: &str) -> IResult<&str, i64> {
   let (i, init) = factor(i)?;
 
   fold_many0(
-    (alt((char('*'), char('/'))), factor),
+    (alt(('*', '/')), factor),
     move || init,
     |acc, (op, val): (char, i64)| {
       if op == '*' {
@@ -52,7 +51,7 @@ fn expr(i: &str) -> IResult<&str, i64> {
   let (i, init) = term(i)?;
 
   fold_many0(
-    (alt((char('+'), char('-'))), term),
+    (alt(('+', '-')), term),
     move || init,
     |acc, (op, val): (char, i64)| {
       if op == '+' {

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use nom::prelude::*;
 use nom::{
   branch::alt,
-  bytes::tag,
   character::{digit1 as digit, multispace0 as multispace},
   multi::many0,
   sequence::{delimited, preceded},
@@ -61,7 +60,7 @@ impl Debug for Expr {
 fn parens(i: &str) -> IResult<&str, Expr> {
   delimited(
     multispace,
-    delimited(tag("("), expr.map(|e| Expr::Paren(Box::new(e))), tag(")")),
+    delimited("(", expr.map(|e| Expr::Paren(Box::new(e))), ")"),
     multispace,
   )(i)
 }
@@ -91,11 +90,11 @@ fn term(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = factor(i)?;
   let (i, remainder) = many0(alt((
     |i| {
-      let (i, mul) = preceded(tag("*"), factor)(i)?;
+      let (i, mul) = preceded("*", factor)(i)?;
       Ok((i, (Oper::Mul, mul)))
     },
     |i| {
-      let (i, div) = preceded(tag("/"), factor)(i)?;
+      let (i, div) = preceded("/", factor)(i)?;
       Ok((i, (Oper::Div, div)))
     },
   )))(i)?;
@@ -107,11 +106,11 @@ fn expr(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = term(i)?;
   let (i, remainder) = many0(alt((
     |i| {
-      let (i, add) = preceded(tag("+"), term)(i)?;
+      let (i, add) = preceded("+", term)(i)?;
       Ok((i, (Oper::Add, add)))
     },
     |i| {
-      let (i, sub) = preceded(tag("-"), term)(i)?;
+      let (i, sub) = preceded("-", term)(i)?;
       Ok((i, (Oper::Sub, sub)))
     },
   )))(i)?;

--- a/tests/escaped.rs
+++ b/tests/escaped.rs
@@ -9,8 +9,8 @@ fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
 
 #[cfg(feature = "alloc")]
 fn esc_trans(s: &str) -> IResult<&str, String, (&str, ErrorKind)> {
-  use nom::bytes::{escaped_transform, tag};
-  escaped_transform(digit1, '\\', tag("n"))(s)
+  use nom::bytes::escaped_transform;
+  escaped_transform(digit1, '\\', "n")(s)
 }
 
 #[test]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -1,5 +1,4 @@
 use nom::branch::alt;
-use nom::bytes::tag;
 use nom::character::digit1 as digit;
 use nom::combinator::opt;
 use nom::prelude::*;
@@ -11,8 +10,8 @@ use std::str::FromStr;
 
 fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
   let float_bytes = alt((
-    delimited(digit, tag("."), opt(digit)),
-    delimited(opt(digit), tag("."), digit),
+    delimited(digit, ".", opt(digit)),
+    delimited(opt(digit), ".", digit),
   ))
   .recognize();
   let float_str = float_bytes.map_res(str::from_utf8);
@@ -20,7 +19,7 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
 }
 
 fn float(i: &[u8]) -> IResult<&[u8], f32> {
-  (opt(alt((tag("+"), tag("-")))), unsigned_float)
+  (opt(alt(("+", "-"))), unsigned_float)
     .map(|(sign, value)| {
       sign
         .and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -1,7 +1,7 @@
 use nom::prelude::*;
 use nom::{
   bytes::take_while,
-  character::{alphanumeric1 as alphanumeric, char, multispace0 as multispace, space0 as space},
+  character::{alphanumeric1 as alphanumeric, multispace0 as multispace, space0 as space},
   combinator::opt,
   multi::many0,
   sequence::{delimited, separated_pair, terminated},
@@ -11,18 +11,18 @@ use std::collections::HashMap;
 use std::str;
 
 fn category(i: &[u8]) -> IResult<&[u8], &str> {
-  delimited(char('['), take_while(|c| c != b']'), char(']'))
+  delimited('[', take_while(|c| c != b']'), ']')
     .map_res(str::from_utf8)
     .parse(i)
 }
 
 fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
   let (i, key) = alphanumeric.map_res(str::from_utf8).parse(i)?;
-  let (i, _) = (opt(space), char('='), opt(space)).parse(i)?;
+  let (i, _) = (opt(space), '=', opt(space)).parse(i)?;
   let (i, val) = take_while(|c| c != b'\n' && c != b';')
     .map_res(str::from_utf8)
     .parse(i)?;
-  let (i, _) = opt((char(';'), take_while(|c| c != b'\n')))(i)?;
+  let (i, _) = opt((';', take_while(|c| c != b'\n')))(i)?;
   Ok((i, (key, val)))
 }
 

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,6 +1,6 @@
 use nom::prelude::*;
 use nom::{
-  bytes::{tag, take_till, take_while, take_while1},
+  bytes::{take_till, take_while, take_while1},
   character::{alphanumeric1 as alphanumeric, space0 as space},
   combinator::opt,
   multi::many0,
@@ -30,10 +30,10 @@ fn category(i: &str) -> IResult<&str, &str> {
 
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
-  let (i, _) = (opt(space), tag("="), opt(space)).parse(i)?;
+  let (i, _) = (opt(space), "=", opt(space)).parse(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
   let (i, _) = opt(space)(i)?;
-  let (i, _) = opt((tag(";"), not_line_ending))(i)?;
+  let (i, _) = opt((";", not_line_ending))(i)?;
   let (i, _) = opt(space_or_line_ending)(i)?;
 
   Ok((i, (key, val)))

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -1,7 +1,7 @@
 use nom::prelude::*;
 use nom::{
   bytes::{tag, take_till, take_while, take_while1},
-  character::{alphanumeric1 as alphanumeric, char, space0 as space},
+  character::{alphanumeric1 as alphanumeric, space0 as space},
   combinator::opt,
   multi::many0,
   sequence::{delimited, terminated},
@@ -23,7 +23,7 @@ fn space_or_line_ending(i: &str) -> IResult<&str, &str> {
 
 fn category(i: &str) -> IResult<&str, &str> {
   terminated(
-    delimited(char('['), take_while(|c| c != ']'), char(']')),
+    delimited('[', take_while(|c| c != ']'), ']'),
     opt(take_while1(" \r\n")),
   )(i)
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -195,20 +195,18 @@ fn issue_942() {
 
 #[test]
 fn issue_many_m_n_with_zeros() {
-  use nom::character::char;
   use nom::multi::many_m_n;
-  let mut parser = many_m_n::<_, _, (), _>(0, 0, char('a'));
+  let mut parser = many_m_n::<_, _, (), _>(0, 0, 'a');
   assert_eq!(parser("aaa"), Ok(("aaa", vec![])));
 }
 
 #[test]
 fn issue_1027_convert_error_panic_nonempty() {
-  use nom::character::char;
   use nom::error::{convert_error, VerboseError};
 
   let input = "a";
 
-  let result: IResult<_, _, VerboseError<&str>> = (char('a'), char('b')).parse(input);
+  let result: IResult<_, _, VerboseError<&str>> = ('a', 'b').parse(input);
   let err = match result.unwrap_err() {
     Err::Error(e) => e,
     _ => unreachable!(),
@@ -241,15 +239,13 @@ fn issue_1282_findtoken_char() {
 
 #[test]
 fn issue_1459_clamp_capacity() {
-  use nom::character::char;
-
   // shouldn't panic
   use nom::multi::many_m_n;
-  let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, char('a'));
+  let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, 'a');
   assert_eq!(parser("a"), Err(nom::Err::Error(())));
 
   // shouldn't panic
   use nom::multi::count;
-  let mut parser = count::<_, _, (), _>(char('a'), usize::MAX);
+  let mut parser = count::<_, _, (), _>('a', usize::MAX);
   assert_eq!(parser("a"), Err(nom::Err::Error(())));
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -39,7 +39,7 @@ fn unicode_escape(input: &str) -> IResult<&str, char> {
       .verify(|cp| !(0xD800..0xE000).contains(cp))
       .map(|cp| cp as u32),
     // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-    separated_pair(u16_hex, tag("\\u"), u16_hex)
+    separated_pair(u16_hex, "\\u", u16_hex)
       .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
       .map(|(high, low)| {
         let high_ten = (high as u32) - 0xD800;

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -4,7 +4,6 @@
 use std::str;
 
 use nom::bytes::take_till1;
-use nom::character::char;
 use nom::multi::fold_many0;
 use nom::prelude::*;
 use nom::sequence::delimited;
@@ -22,10 +21,10 @@ fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Stri
 // FIXME: should we support the use case of borrowing data mutably in a parser?
 fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> IResult<&'a [u8], String> {
   delimited(
-    char('('),
+    '(',
     fold_many0(atom(tomb), String::new, |acc: String, next: String| {
       acc + next.as_str()
     }),
-    char(')'),
+    ')',
   )(i)
 }


### PR DESCRIPTION
We now support
- `&str` and `&[u8]` as `tag` parsers
- `char` as a `char` parser and `u8` as a `one_of` parser
- u8 and char ranges as `one_of` parsers

This is to allow reducing noise and making more natural to write a parser.  The downside is when running into type inference issues.

The other downside is that this prevents us from moving `Parser` and `IResult` into a `-core` crate.  However, I would expected we'd need most of `nom::input` in that as well which would be harder to keep compatibility on I suspect.

Fixes Geal/nom#1417
Fixes Geal/nom#1408