### PR TITLE
fix(parser)!: Split Parser::into into Parser::output_into and Parser::err_into

### DIFF
--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -255,7 +255,7 @@ fn test_parser_into() {
     Err,
   };
 
-  let mut parser = Parser::into(take::<_, _, Error<_>, false>(3u8));
+  let mut parser = take::<_, _, Error<_>, false>(3u8).output_into();
   let result: IResult<&[u8], Vec<u8>> = parser.parse(&b"abcdefg"[..]);
 
   assert_eq!(result, Ok((&b"defg"[..], vec![97, 98, 99])));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -434,6 +434,34 @@ pub trait Parser<I, O, E> {
     Value::new(self, val)
   }
 
+  /// Convert the parser's output to another type using [`std::convert::From`]
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use nom::IResult;
+  /// # use nom::Parser;
+  /// use nom::character::alpha1;
+  /// # fn main() {
+  ///
+  ///  fn parser1(i: &str) -> IResult<&str, &str> {
+  ///    alpha1(i)
+  ///  }
+  ///
+  ///  let mut parser2 = parser1.output_into();
+  ///
+  /// // the parser converts the &str output of the child parser into a Vec<u8>
+  /// let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
+  /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
+  /// # }
+  /// ```
+  fn output_into<O2: From<O>>(self) -> OutputInto<Self, O, O2>
+  where
+    Self: core::marker::Sized,
+  {
+    OutputInto::new(self)
+  }
+
   /// If the child parser was successful, return the consumed input as produced value.
   ///
   /// # Example
@@ -696,6 +724,14 @@ pub trait Parser<I, O, E> {
     Complete::new(self)
   }
 
+  /// Convert the parser's error to another type using [`std::convert::From`]
+  fn err_into<E2: From<E>>(self) -> ErrInto<Self, E, E2>
+  where
+    Self: core::marker::Sized,
+  {
+    ErrInto::new(self)
+  }
+
   /// Prints a message and the input if the parser fails.
   ///
   /// The message prints the `Error` or `Incomplete`
@@ -751,42 +787,6 @@ pub trait Parser<I, O, E> {
     Self: core::marker::Sized,
   {
     Or::new(self, g)
-  }
-
-  /// Convert the parser's output to another type using [`std::convert::From`]
-  ///
-  /// # Example
-  ///
-  /// ```rust
-  /// # use nom::IResult;
-  /// # use nom::Parser;
-  /// use nom::character::alpha1;
-  /// # fn main() {
-  ///
-  ///  fn parser1(i: &str) -> IResult<&str, &str> {
-  ///    alpha1(i)
-  ///  }
-  ///
-  ///  let mut parser2 = parser1.output_into();
-  ///
-  /// // the parser converts the &str output of the child parser into a Vec<u8>
-  /// let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
-  /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
-  /// # }
-  /// ```
-  fn output_into<O2: From<O>>(self) -> OutputInto<Self, O, O2>
-  where
-    Self: core::marker::Sized,
-  {
-    OutputInto::new(self)
-  }
-
-  /// Convert the parser's error to another type using [`std::convert::From`]
-  fn err_into<E2: From<E>>(self) -> ErrInto<Self, E, E2>
-  where
-    Self: core::marker::Sized,
-  {
-    ErrInto::new(self)
   }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -753,8 +753,7 @@ pub trait Parser<I, O, E> {
     Or::new(self, g)
   }
 
-  /// automatically converts the parser's output and error values to another type, as long as they
-  /// implement the `From` trait
+  /// Convert the parser's output to another type using [`std::convert::From`]
   ///
   /// # Example
   ///
@@ -768,18 +767,26 @@ pub trait Parser<I, O, E> {
   ///    alpha1(i)
   ///  }
   ///
-  ///  let mut parser2 = Parser::into(parser1);
+  ///  let mut parser2 = parser1.output_into();
   ///
   /// // the parser converts the &str output of the child parser into a Vec<u8>
   /// let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
   /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
   /// # }
   /// ```
-  fn into<O2: From<O>, E2: From<E>>(self) -> Into<Self, O, O2, E, E2>
+  fn output_into<O2: From<O>>(self) -> OutputInto<Self, O, O2>
   where
     Self: core::marker::Sized,
   {
-    Into::new(self)
+    OutputInto::new(self)
+  }
+
+  /// Convert the parser's error to another type using [`std::convert::From`]
+  fn err_into<E2: From<E>>(self) -> ErrInto<Self, E, E2>
+  where
+    Self: core::marker::Sized,
+  {
+    ErrInto::new(self)
   }
 }
 


### PR DESCRIPTION
Bringing in the `Parser` trait prevents using `Into::into` and
`Parser::into` as postfix.  One way to fix this is to rename
`Parser::into` but the only idea I had for doing so was to split it
which I think makes more sense.