### PR TITLE
feat(error)!: Make Context content generic

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -92,7 +92,7 @@ fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {
 /// parsing the string
 /// - `context` lets you add a static string to provide more information in the
 /// error chain (to indicate which parser had an error)
-fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn string<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
   preceded('\"', cut(terminated(parse_str, '\"')))
@@ -104,7 +104,7 @@ fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 /// accumulating results in a `Vec`, until it encounters an error.
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
-fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn array<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, Vec<JsonValue>, E> {
   preceded(
@@ -118,13 +118,13 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   .parse(i)
 }
 
-fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, (&'a str, JsonValue), E> {
   separated_pair(preceded(sp, string), cut(preceded(sp, ':')), json_value)(i)
 }
 
-fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, HashMap<String, JsonValue>, E> {
   preceded(
@@ -144,7 +144,7 @@ fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 }
 
 /// here, we apply the space parser before trying to parse a value
-fn json_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn json_value<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, JsonValue, E> {
   preceded(
@@ -161,7 +161,7 @@ fn json_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 }
 
 /// the root element of a JSON parser is either an object or an array
-fn root<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+fn root<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
   i: &'a str,
 ) -> IResult<&'a str, JsonValue, E> {
   delimited(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use self::Needed::*;
 use crate::combinator::*;
 #[cfg(feature = "std")]
 use crate::error::DbgErr;
-use crate::error::{self, Context, ErrorKind, ParseError};
+use crate::error::{self, Context, ContextError, ErrorKind, ParseError};
 use crate::input::InputIsStreaming;
 use crate::input::*;
 use crate::lib::std::fmt;
@@ -695,9 +695,11 @@ pub trait Parser<I, O, E> {
   ///
   /// This is used mainly to add user friendly information
   /// to errors when backtracking through a parse tree.
-  fn context(self, context: &'static str) -> Context<Self, O>
+  fn context<C>(self, context: C) -> Context<Self, O, C>
   where
     Self: core::marker::Sized,
+    C: Clone,
+    E: ContextError<I, C>,
   {
     Context::new(self, context)
   }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -184,7 +184,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
 #[test]
 fn issue_942() {
   use nom::error::{ContextError, ParseError};
-  pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+  pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
     i: &'a str,
   ) -> IResult<&'a str, usize, E> {
     use nom::{character::char, multi::many0_count};


### PR DESCRIPTION
An example of an error I regression in switching `toml_edit` from `nom` to `combine`:
```
---- expected: tests/fixtures/invalid/table-with-pound.stderr
+++ Actual
   1    1 | TOML parse error at line 1, column 5
   2    2 |   |
   3    3 | 1 | [key#group]
   4    4 |   |     ^
   5      - Unexpected `#`
   6      - Expected `.` or `]`
        5 +
   7    6 | While parsing a Table Header
```

While I might not expect `nom` to report expected content automatically (yet?), I want to be able to manually build up the pieces.  Part of this is storing more than just `context: &'static str`.  I could go off and create more related traits but a simpler route is just making context generic.  This allows users to create their own context enum with all of the variants each parser needs.

This was inspired by `nom-supreme` which has its own error context to do just this.

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
