### PR TITLE
fix(bits)!: Don't re-export in root namespace 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,6 @@ pub mod lib {
   }
 }
 
-pub use self::bits::*;
 pub use self::parser::*;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,6 @@ pub mod lib {
 pub use self::bits::*;
 pub use self::parser::*;
 
-pub use self::str::*;
-
 #[macro_use]
 mod macros;
 #[macro_use]


### PR DESCRIPTION
This is an unusual elevation of a specific subset of parsers with
unclearly named `nom::complete` and `nom::streaming` modules and we are
now putting even more items in the root namespace as we move away from
complete/streaming.